### PR TITLE
fix(docker): correctly expose port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,4 @@ COPY ./static ./static
 
 RUN VITE_TARGET_ENVIRONMENT=${TARGET_ENVIRONMENT} npm run build
 
-EXPOSE 5173
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "release"]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",
+		"release": "vite dev --host",
 		"build": "vite build",
 		"preview": "vite preview",
 		"test": "npm run test:integration && npm run test:unit",


### PR DESCRIPTION
It seems setting `server.host: true` is not enough for vite to actually run the server on `0.0.0.0`.
For it to actually respect the setting it seems you have to pass `--host`.