### PR TITLE
Naples, Uppsala, Rome-OPBG display names added

### DIFF
--- a/static/config/options.json
+++ b/static/config/options.json
@@ -30,6 +30,8 @@
         "goettingen": "Göttingen",
         "hannover": "Hannover",
         "rome": "Rome-BBIRE",
+        "rome-opbg": "Rome-OPBG",
+        "uppsala": "Uppsala",
         "uppsala-test": "Uppsala-Test",
         "eric-test": "ERIC-Test",
         "prague-uhkt-test": "Prague-UHKT-Test"

--- a/static/config/options.json
+++ b/static/config/options.json
@@ -13,7 +13,7 @@
         "cyprus": "Cyprus",
         "leipzig": "Leipzig",
         "muenchen-hmgu": "München-HMGU",
-        "Pilsen": "Pilsen",
+        "pilsen": "Pilsen",
         "olomouc": "Olomouc",
         "prague-ffm": "Prague-FFM",
         "prague-ior": "Prague-IoR",

--- a/static/config/options.json
+++ b/static/config/options.json
@@ -18,7 +18,7 @@
         "prague-ffm": "Prague-FFM",
         "prague-ior": "Prague-IoR",
         "mannheim": "Mannheim",
-        "naples-pascale", "Naples-Pascale",
+        "naples-pascale": "Naples-Pascale",
         "heidelberg": "Heidelberg",
         "frankfurt": "Frankfurt",
         "dresden": "Dresden",

--- a/static/config/options.json
+++ b/static/config/options.json
@@ -18,6 +18,7 @@
         "prague-ffm": "Prague-FFM",
         "prague-ior": "Prague-IoR",
         "mannheim": "Mannheim",
+        "naples-pascale", "Naples-Pascale",
         "heidelberg": "Heidelberg",
         "frankfurt": "Frankfurt",
         "dresden": "Dresden",


### PR DESCRIPTION
Naples, Uppsala, Rome-OPBG display names added to the map containing display names of the sites. (Were missing because the initial copypaste happened before those sites were enrolled in the old locator.) This should fix the ridiculous alignment in the result table, but who knows. Gotta merge to see. 

![image](https://github.com/user-attachments/assets/c094260d-5a6e-4ba5-b329-e4e431773090)
