### PR TITLE
Ensure nightly builds don't use production tag

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - develop
+  schedule:
+    # Build every night at 1am
+    - cron: '0 1 * * *'
 jobs:
   build:
     # Necessary after this repository was renamed from samply/lens-web-components to samply/lens
@@ -20,10 +23,10 @@ jobs:
     # Visit: https://github.com/samply/github-workflows/blob/main/.github/workflows/docker-ci.yml, for more information
     uses: samply/github-workflows/.github/workflows/docker-ci.yml@main
     with:
-      image-name: "samply/bbmri-sample-locator"
+      image-name: 'samply/bbmri-sample-locator'
       build-args: |
         TARGET_ENVIRONMENT=staging
-      build-platforms: "linux/amd64"
+      build-platforms: 'linux/amd64'
       push-to: dockerhub
     # This passes the secrets from calling workflow to the called workflow
     secrets:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "bbmri-sample-locator",
-	"version": "0.0.1",
+	"version": "1.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "bbmri-sample-locator",
-			"version": "0.0.1",
+			"version": "1.0.1",
 			"dependencies": {
 				"@samply/lens": "0.4.4-0",
 				"uuid": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bbmri-sample-locator",
-	"version": "0.0.1",
+	"version": "1.0.1",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
By default, GitHub only supports to build the default branch with a schedule (https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule). Due to our resent change of the default branch from main to develop, this leads to develop images being build as "production". This PR fixes this.