### PR TITLE
Revert "chore: update lens to version 0.4.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "bbmri-sample-locator",
 			"version": "1.0.2",
 			"dependencies": {
-				"@samply/lens": "0.4.5",
+				"@samply/lens": "0.4.4-0",
 				"uuid": "^10.0.0"
 			},
 			"devDependencies": {
@@ -1399,27 +1399,27 @@
 			]
 		},
 		"node_modules/@samply/lens": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/@samply/lens/-/lens-0.4.5.tgz",
-			"integrity": "sha512-bvCAmIKgqnE84dTBZuazh6skSugHysYIEjQoVILZ83KuWjvg29XA2xshve2OK2fvhGHHNiOMP0O7GjG4frIf8w==",
+			"version": "0.4.4-0",
+			"resolved": "https://registry.npmjs.org/@samply/lens/-/lens-0.4.4-0.tgz",
+			"integrity": "sha512-bajnNfs+9Ovk64ec5cazfGUJiEEC2T9/IpqBndgB16MMMvbvmkJ1DtT9eWQcY/ZgbhonSPULzYF1DfnBghYZkQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@exodus/schemasafe": "^1.3.0",
-				"chart.js": "^4.4.6",
-				"uuid": "^11.0.3"
+				"chart.js": "^4.4.0",
+				"uuid": "^9.0.0"
 			}
 		},
 		"node_modules/@samply/lens/node_modules/uuid": {
-			"version": "11.0.5",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
-			"integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+			"integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/esm/bin/uuid"
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@samply/lens": "0.4.5",
+		"@samply/lens": "0.4.4-0",
 		"uuid": "^10.0.0"
 	}
 }

--- a/static/config/options-test.json
+++ b/static/config/options-test.json
@@ -98,7 +98,7 @@
         ]
     },
     "negotiateOptions": {
-        "url": "https://negotiator.acc.bbmri-eric.eu/api/v3/requests",
+        "newProjectUrl": "https://negotiator.acc.bbmri-eric.eu/api/v3/requests",
         "siteMappings": [
             {
                 "site": "ERIC-Test",

--- a/static/config/options.json
+++ b/static/config/options.json
@@ -123,7 +123,7 @@
         ]
     },
     "negotiateOptions": {
-        "url": "https://negotiator.bbmri-eric.eu/api/v3/requests",
+        "newProjectUrl": "https://negotiator.bbmri-eric.eu/api/v3/requests",
         "siteMappings": [
             {
                 "site": "Aachen",


### PR DESCRIPTION
The AST Schema is corrupted. For example, the empty query is this:
{"ast":{"nodeType":"branch","operand":"OR","children":[{"nodeType":"branch","operand":"AND","children":[]}]},"id":"0b29f6d1-4e6a-4679-9212-3327e498b304__search__0b29f6d1-4e6a-4679-9212-3327e498b304"}

and it should be this:
{"ast":{"operand":"OR","children":[]},"id":"72665087-cbc1-47af-9737-89d13117d28b__search__72665087-cbc1-47af-9737-89d13117d28b"}

Fix the AST in Lens core before upping its version!