### PR TITLE
chore: remove @samply/lens from optimizeDeps.include in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,9 +6,6 @@ export default defineConfig({
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	},
-	optimizeDeps: {
-		include: ['@samply/lens'], // Make sure the package is correctly included
-	},
 	ssr: {
 		noExternal: ['@samply/lens'], // Mark package as noExternal if SSR issues
 	}


### PR DESCRIPTION
I'm suggesting to remove these lines from `vite.config.ts`:

```ts
optimizeDeps: {
    include: ['@samply/lens'],
},
```

They break the following workflow:
1. Clone lens and run `npm run watch`
2. Clone bbmri-sample-locator and run `npm install path/to/lens/repo`
3. In the same directory run `npm run dev`
4. Develop on lens and immediately see the changes in bbmri-sample-locator

From [the Vite documentation of optimizeDep.include](https://vite.dev/config/dep-optimization-options#optimizedeps-include):

> By default, linked packages not inside node_modules are not pre-bundled. Use this option to force a linked package to be pre-bundled.

Usually lens is inside node_modules and thus should be pre-bundled anyways, right? So deleting this configuration shouldn't change anything except when lens is symlinked as in the workflow I described above.