### PR TITLE
chore: fix negotiate button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "bbmri-sample-locator",
 			"version": "1.0.5",
 			"dependencies": {
-				"@samply/lens": "^0.4.6-0",
+				"@samply/lens": "0.4.6-0",
 				"uuid": "^10.0.0"
 			},
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@samply/lens": "^0.4.6-0",
+		"@samply/lens": "0.4.6-0",
 		"uuid": "^10.0.0"
 	}
 }


### PR DESCRIPTION
The negotiate button broke because since the release of lens 0.4.6, the version specifier ^0.4.6-0 in package.json was automatically pointing to the new version. This commit fixes it by exactly specifying the version without the caret.

### General Summary

### Description
<!--- Describe changes in detail -->

### Related Issue
<!--- Please link to the issue here: -->

---

### Motivation and Context

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

### Screenshots (if appropriate):

---

<!--- Please check if the PR fulfills these requirements -->
- [ ] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
