### PR TITLE
ci: disable production nightly build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,9 +10,11 @@ on:
   pull_request:
     branches:
       - main
-  schedule:
+  # The nightly build is deactivated for now, as it overwrites the TARGET_ENV=staging builds, potentially leading to
+  # production data in the staging environment. This is a quickfix and the CI action needs to be modified.
+  # schedule:
     # Build every night at 1am
-    - cron: '0 1 * * *'
+    # - cron: '0 1 * * *'
 jobs:
   build:
     # Necessary after this repository was renamed from samply/lens-web-components to samply/lens


### PR DESCRIPTION
### General Summary

### Description
Currently the production nightly build overwites the staging image. This disables the production nightly and is to be reverted once the docker-ci action is fixed.

### Related Issue
No related issue

---

### Motivation and Context

### How Has This Been Tested?

### Screenshots (if appropriate):

---

<!--- Please check if the PR fulfills these requirements -->
- [ ] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
