### PR TITLE
chore: also show diagnosis codes without % or digit

### DIFF
--- a/static/catalogues/catalogue-bbmri.json
+++ b/static/catalogues/catalogue-bbmri.json
@@ -74,7 +74,6 @@
                                     {
                                         "key": "A00",
                                         "name": "A00",
-                                        "visible": false,
                                         "description": "Cholera"
                                     }
                                 ]
@@ -112,7 +111,6 @@
                                     {
                                         "key": "A01",
                                         "name": "A01",
-                                        "visible": false,
                                         "description": "Typhoid and paratyphoid fevers"
                                     }
                                 ]
@@ -150,7 +148,6 @@
                                     {
                                         "key": "A02",
                                         "name": "A02",
-                                        "visible": false,
                                         "description": "Other salmonella infections"
                                     }
                                 ]
@@ -193,7 +190,6 @@
                                     {
                                         "key": "A03",
                                         "name": "A03",
-                                        "visible": false,
                                         "description": "Shigellosis"
                                     }
                                 ]
@@ -256,7 +252,6 @@
                                     {
                                         "key": "A04",
                                         "name": "A04",
-                                        "visible": false,
                                         "description": "Other bacterial intestinal infections"
                                     }
                                 ]
@@ -304,7 +299,6 @@
                                     {
                                         "key": "A05",
                                         "name": "A05",
-                                        "visible": false,
                                         "description": "Other bacterial foodborne intoxications, not elsewhere classified"
                                     }
                                 ]
@@ -352,7 +346,6 @@
                                     {
                                         "key": "A06",
                                         "name": "A06",
-                                        "visible": false,
                                         "description": "Amoebiasis"
                                     }
                                 ]
@@ -395,7 +388,6 @@
                                     {
                                         "key": "A07",
                                         "name": "A07",
-                                        "visible": false,
                                         "description": "Other protozoal intestinal diseases"
                                     }
                                 ]
@@ -438,7 +430,6 @@
                                     {
                                         "key": "A08",
                                         "name": "A08",
-                                        "visible": false,
                                         "description": "Viral and other specified intestinal infections"
                                     }
                                 ]
@@ -461,7 +452,6 @@
                                     {
                                         "key": "A09",
                                         "name": "A09",
-                                        "visible": false,
                                         "description": "Other gastroenteritis and colitis of infectious and unspecified origin"
                                     }
                                 ]
@@ -524,7 +514,6 @@
                                     {
                                         "key": "A15",
                                         "name": "A15",
-                                        "visible": false,
                                         "description": "Respiratory tuberculosis, bacteriologically and histologically confirmed"
                                     }
                                 ]
@@ -582,7 +571,6 @@
                                     {
                                         "key": "A16",
                                         "name": "A16",
-                                        "visible": false,
                                         "description": "Respiratory tuberculosis, not confirmed bacteriologically or histologically"
                                     }
                                 ]
@@ -630,7 +618,6 @@
                                     {
                                         "key": "A18",
                                         "name": "A18",
-                                        "visible": false,
                                         "description": "Tuberculosis of other organs"
                                     }
                                 ]
@@ -668,7 +655,6 @@
                                     {
                                         "key": "A19",
                                         "name": "A19",
-                                        "visible": false,
                                         "description": "Miliary tuberculosis"
                                     }
                                 ]
@@ -716,7 +702,6 @@
                                     {
                                         "key": "A20",
                                         "name": "A20",
-                                        "visible": false,
                                         "description": "Plague"
                                     }
                                 ]
@@ -764,7 +749,6 @@
                                     {
                                         "key": "A21",
                                         "name": "A21",
-                                        "visible": false,
                                         "description": "Tularaemia"
                                     }
                                 ]
@@ -807,7 +791,6 @@
                                     {
                                         "key": "A22",
                                         "name": "A22",
-                                        "visible": false,
                                         "description": "Anthrax"
                                     }
                                 ]
@@ -850,7 +833,6 @@
                                     {
                                         "key": "A23",
                                         "name": "A23",
-                                        "visible": false,
                                         "description": "Brucellosis"
                                     }
                                 ]
@@ -888,7 +870,6 @@
                                     {
                                         "key": "A24",
                                         "name": "A24",
-                                        "visible": false,
                                         "description": "Glanders and melioidosis"
                                     }
                                 ]
@@ -916,7 +897,6 @@
                                     {
                                         "key": "A25",
                                         "name": "A25",
-                                        "visible": false,
                                         "description": "Rat-bite fevers"
                                     }
                                 ]
@@ -949,7 +929,6 @@
                                     {
                                         "key": "A26",
                                         "name": "A26",
-                                        "visible": false,
                                         "description": "Erysipeloid"
                                     }
                                 ]
@@ -977,7 +956,6 @@
                                     {
                                         "key": "A27",
                                         "name": "A27",
-                                        "visible": false,
                                         "description": "Leptospirosis"
                                     }
                                 ]
@@ -1015,7 +993,6 @@
                                     {
                                         "key": "A28",
                                         "name": "A28",
-                                        "visible": false,
                                         "description": "Other zoonotic bacterial diseases, not elsewhere classified"
                                     }
                                 ]
@@ -1068,7 +1045,6 @@
                                     {
                                         "key": "A30",
                                         "name": "A30",
-                                        "visible": false,
                                         "description": "Leprosy [Hansen disease]"
                                     }
                                 ]
@@ -1101,7 +1077,6 @@
                                     {
                                         "key": "A31",
                                         "name": "A31",
-                                        "visible": false,
                                         "description": "Infection due to other mycobacteria"
                                     }
                                 ]
@@ -1134,7 +1109,6 @@
                                     {
                                         "key": "A32",
                                         "name": "A32",
-                                        "visible": false,
                                         "description": "Listeriosis"
                                     }
                                 ]
@@ -1192,7 +1166,6 @@
                                     {
                                         "key": "A36",
                                         "name": "A36",
-                                        "visible": false,
                                         "description": "Diphtheria"
                                     }
                                 ]
@@ -1225,7 +1198,6 @@
                                     {
                                         "key": "A37",
                                         "name": "A37",
-                                        "visible": false,
                                         "description": "Whooping cough"
                                     }
                                 ]
@@ -1268,7 +1240,6 @@
                                     {
                                         "key": "A39",
                                         "name": "A39",
-                                        "visible": false,
                                         "description": "Meningococcal infection"
                                     }
                                 ]
@@ -1311,7 +1282,6 @@
                                     {
                                         "key": "A40",
                                         "name": "A40",
-                                        "visible": false,
                                         "description": "Streptococcal sepsis"
                                     }
                                 ]
@@ -1364,7 +1334,6 @@
                                     {
                                         "key": "A41",
                                         "name": "A41",
-                                        "visible": false,
                                         "description": "Other sepsis"
                                     }
                                 ]
@@ -1407,7 +1376,6 @@
                                     {
                                         "key": "A42",
                                         "name": "A42",
-                                        "visible": false,
                                         "description": "Actinomycosis"
                                     }
                                 ]
@@ -1440,7 +1408,6 @@
                                     {
                                         "key": "A43",
                                         "name": "A43",
-                                        "visible": false,
                                         "description": "Nocardiosis"
                                     }
                                 ]
@@ -1473,7 +1440,6 @@
                                     {
                                         "key": "A44",
                                         "name": "A44",
-                                        "visible": false,
                                         "description": "Bartonellosis"
                                     }
                                 ]
@@ -1521,7 +1487,6 @@
                                     {
                                         "key": "A48",
                                         "name": "A48",
-                                        "visible": false,
                                         "description": "Other bacterial diseases, not elsewhere classified"
                                     }
                                 ]
@@ -1564,7 +1529,6 @@
                                     {
                                         "key": "A49",
                                         "name": "A49",
-                                        "visible": false,
                                         "description": "Bacterial infection of unspecified site"
                                     }
                                 ]
@@ -1622,7 +1586,6 @@
                                     {
                                         "key": "A50",
                                         "name": "A50",
-                                        "visible": false,
                                         "description": "Congenital syphilis"
                                     }
                                 ]
@@ -1670,7 +1633,6 @@
                                     {
                                         "key": "A51",
                                         "name": "A51",
-                                        "visible": false,
                                         "description": "Early syphilis"
                                     }
                                 ]
@@ -1713,7 +1675,6 @@
                                     {
                                         "key": "A52",
                                         "name": "A52",
-                                        "visible": false,
                                         "description": "Late syphilis"
                                     }
                                 ]
@@ -1736,7 +1697,6 @@
                                     {
                                         "key": "A53",
                                         "name": "A53",
-                                        "visible": false,
                                         "description": "Other and unspecified syphilis"
                                     }
                                 ]
@@ -1789,7 +1749,6 @@
                                     {
                                         "key": "A54",
                                         "name": "A54",
-                                        "visible": false,
                                         "description": "Gonococcal infection"
                                     }
                                 ]
@@ -1837,7 +1796,6 @@
                                     {
                                         "key": "A56",
                                         "name": "A56",
-                                        "visible": false,
                                         "description": "Other sexually transmitted chlamydial diseases"
                                     }
                                 ]
@@ -1875,7 +1833,6 @@
                                     {
                                         "key": "A59",
                                         "name": "A59",
-                                        "visible": false,
                                         "description": "Trichomoniasis"
                                     }
                                 ]
@@ -1903,7 +1860,6 @@
                                     {
                                         "key": "A60",
                                         "name": "A60",
-                                        "visible": false,
                                         "description": "Anogenital herpesviral [herpes simplex] infection"
                                     }
                                 ]
@@ -1926,7 +1882,6 @@
                                     {
                                         "key": "A63",
                                         "name": "A63",
-                                        "visible": false,
                                         "description": "Other predominantly sexually transmitted diseases, not elsewhere classified"
                                     }
                                 ]
@@ -1999,7 +1954,6 @@
                                     {
                                         "key": "A66",
                                         "name": "A66",
-                                        "visible": false,
                                         "description": "Yaws"
                                     }
                                 ]
@@ -2037,7 +1991,6 @@
                                     {
                                         "key": "A67",
                                         "name": "A67",
-                                        "visible": false,
                                         "description": "Pinta [carate]"
                                     }
                                 ]
@@ -2065,7 +2018,6 @@
                                     {
                                         "key": "A68",
                                         "name": "A68",
-                                        "visible": false,
                                         "description": "Relapsing fevers"
                                     }
                                 ]
@@ -2103,7 +2055,6 @@
                                     {
                                         "key": "A69",
                                         "name": "A69",
-                                        "visible": false,
                                         "description": "Other spirochaetal infections"
                                     }
                                 ]
@@ -2136,7 +2087,6 @@
                                     {
                                         "key": "A71",
                                         "name": "A71",
-                                        "visible": false,
                                         "description": "Trachoma"
                                     }
                                 ]
@@ -2159,7 +2109,6 @@
                                     {
                                         "key": "A74",
                                         "name": "A74",
-                                        "visible": false,
                                         "description": "Other diseases caused by chlamydiae"
                                     }
                                 ]
@@ -2197,7 +2146,6 @@
                                     {
                                         "key": "A75",
                                         "name": "A75",
-                                        "visible": false,
                                         "description": "Typhus fever"
                                     }
                                 ]
@@ -2240,7 +2188,6 @@
                                     {
                                         "key": "A77",
                                         "name": "A77",
-                                        "visible": false,
                                         "description": "Spotted fever [tick-borne rickettsioses]"
                                     }
                                 ]
@@ -2278,7 +2225,6 @@
                                     {
                                         "key": "A79",
                                         "name": "A79",
-                                        "visible": false,
                                         "description": "Other rickettsioses"
                                     }
                                 ]
@@ -2321,7 +2267,6 @@
                                     {
                                         "key": "A80",
                                         "name": "A80",
-                                        "visible": false,
                                         "description": "Acute poliomyelitis"
                                     }
                                 ]
@@ -2359,7 +2304,6 @@
                                     {
                                         "key": "A81",
                                         "name": "A81",
-                                        "visible": false,
                                         "description": "Atypical virus infections of central nervous system"
                                     }
                                 ]
@@ -2387,7 +2331,6 @@
                                     {
                                         "key": "A82",
                                         "name": "A82",
-                                        "visible": false,
                                         "description": "Rabies"
                                     }
                                 ]
@@ -2445,7 +2388,6 @@
                                     {
                                         "key": "A83",
                                         "name": "A83",
-                                        "visible": false,
                                         "description": "Mosquito-borne viral encephalitis"
                                     }
                                 ]
@@ -2478,7 +2420,6 @@
                                     {
                                         "key": "A84",
                                         "name": "A84",
-                                        "visible": false,
                                         "description": "Tick-borne viral encephalitis"
                                     }
                                 ]
@@ -2501,7 +2442,6 @@
                                     {
                                         "key": "A85",
                                         "name": "A85",
-                                        "visible": false,
                                         "description": "Other viral encephalitis, not elsewhere classified"
                                     }
                                 ]
@@ -2534,7 +2474,6 @@
                                     {
                                         "key": "A87",
                                         "name": "A87",
-                                        "visible": false,
                                         "description": "Viral meningitis"
                                     }
                                 ]
@@ -2562,7 +2501,6 @@
                                     {
                                         "key": "A88",
                                         "name": "A88",
-                                        "visible": false,
                                         "description": "Other viral infections of central nervous system, not elsewhere classified"
                                     }
                                 ]
@@ -2620,7 +2558,6 @@
                                     {
                                         "key": "A92",
                                         "name": "A92",
-                                        "visible": false,
                                         "description": "Other mosquito-borne viral fevers"
                                     }
                                 ]
@@ -2653,7 +2590,6 @@
                                     {
                                         "key": "A93",
                                         "name": "A93",
-                                        "visible": false,
                                         "description": "Other arthropod-borne viral fevers, not elsewhere classified"
                                     }
                                 ]
@@ -2686,7 +2622,6 @@
                                     {
                                         "key": "A95",
                                         "name": "A95",
-                                        "visible": false,
                                         "description": "Yellow fever"
                                     }
                                 ]
@@ -2724,7 +2659,6 @@
                                     {
                                         "key": "A96",
                                         "name": "A96",
-                                        "visible": false,
                                         "description": "Arenaviral haemorrhagic fever"
                                     }
                                 ]
@@ -2757,7 +2691,6 @@
                                     {
                                         "key": "A97",
                                         "name": "A97",
-                                        "visible": false,
                                         "description": "Dengue"
                                     }
                                 ]
@@ -2805,7 +2738,6 @@
                                     {
                                         "key": "A98",
                                         "name": "A98",
-                                        "visible": false,
                                         "description": "Other viral haemorrhagic fevers, not elsewhere classified"
                                     }
                                 ]
@@ -2865,7 +2797,6 @@
                                     {
                                         "key": "B00",
                                         "name": "B00",
-                                        "visible": false,
                                         "description": "Herpesviral [herpes simplex] infections"
                                     }
                                 ]
@@ -2888,7 +2819,6 @@
                                     {
                                         "key": "B01",
                                         "name": "B01",
-                                        "visible": false,
                                         "description": "Varicella [chickenpox]"
                                     }
                                 ]
@@ -2921,7 +2851,6 @@
                                     {
                                         "key": "B02",
                                         "name": "B02",
-                                        "visible": false,
                                         "description": "Zoster [herpes zoster]"
                                     }
                                 ]
@@ -2959,7 +2888,6 @@
                                     {
                                         "key": "B05",
                                         "name": "B05",
-                                        "visible": false,
                                         "description": "Measles"
                                     }
                                 ]
@@ -2982,7 +2910,6 @@
                                     {
                                         "key": "B06",
                                         "name": "B06",
-                                        "visible": false,
                                         "description": "Rubella [German measles]"
                                     }
                                 ]
@@ -3035,7 +2962,6 @@
                                     {
                                         "key": "B08",
                                         "name": "B08",
-                                        "visible": false,
                                         "description": "Other viral infections characterized by skin and mucous membrane lesions, not elsewhere classified"
                                     }
                                 ]
@@ -3063,7 +2989,6 @@
                                     {
                                         "key": "B15",
                                         "name": "B15",
-                                        "visible": false,
                                         "description": "Acute hepatitis A"
                                     }
                                 ]
@@ -3096,7 +3021,6 @@
                                     {
                                         "key": "B16",
                                         "name": "B16",
-                                        "visible": false,
                                         "description": "Acute hepatitis B"
                                     }
                                 ]
@@ -3134,7 +3058,6 @@
                                     {
                                         "key": "B17",
                                         "name": "B17",
-                                        "visible": false,
                                         "description": "Other acute viral hepatitis"
                                     }
                                 ]
@@ -3177,7 +3100,6 @@
                                     {
                                         "key": "B18",
                                         "name": "B18",
-                                        "visible": false,
                                         "description": "Chronic viral hepatitis"
                                     }
                                 ]
@@ -3200,7 +3122,6 @@
                                     {
                                         "key": "B19",
                                         "name": "B19",
-                                        "visible": false,
                                         "description": "Unspecified viral hepatitis"
                                     }
                                 ]
@@ -3238,7 +3159,6 @@
                                     {
                                         "key": "B23",
                                         "name": "B23",
-                                        "visible": false,
                                         "description": "Human immunodeficiency virus [HIV] disease resulting in other conditions"
                                     }
                                 ]
@@ -3266,7 +3186,6 @@
                                     {
                                         "key": "B25",
                                         "name": "B25",
-                                        "visible": false,
                                         "description": "Cytomegaloviral disease"
                                     }
                                 ]
@@ -3289,7 +3208,6 @@
                                     {
                                         "key": "B26",
                                         "name": "B26",
-                                        "visible": false,
                                         "description": "Mumps"
                                     }
                                 ]
@@ -3322,7 +3240,6 @@
                                     {
                                         "key": "B27",
                                         "name": "B27",
-                                        "visible": false,
                                         "description": "Infectious mononucleosis"
                                     }
                                 ]
@@ -3345,7 +3262,6 @@
                                     {
                                         "key": "B30",
                                         "name": "B30",
-                                        "visible": false,
                                         "description": "Viral conjunctivitis"
                                     }
                                 ]
@@ -3383,7 +3299,6 @@
                                     {
                                         "key": "B33",
                                         "name": "B33",
-                                        "visible": false,
                                         "description": "Other viral diseases, not elsewhere classified"
                                     }
                                 ]
@@ -3431,7 +3346,6 @@
                                     {
                                         "key": "B34",
                                         "name": "B34",
-                                        "visible": false,
                                         "description": "Viral infection of unspecified site"
                                     }
                                 ]
@@ -3489,7 +3403,6 @@
                                     {
                                         "key": "B35",
                                         "name": "B35",
-                                        "visible": false,
                                         "description": "Dermatophytosis"
                                     }
                                 ]
@@ -3532,7 +3445,6 @@
                                     {
                                         "key": "B36",
                                         "name": "B36",
-                                        "visible": false,
                                         "description": "Other superficial mycoses"
                                     }
                                 ]
@@ -3580,7 +3492,6 @@
                                     {
                                         "key": "B37",
                                         "name": "B37",
-                                        "visible": false,
                                         "description": "Candidiasis"
                                     }
                                 ]
@@ -3628,7 +3539,6 @@
                                     {
                                         "key": "B38",
                                         "name": "B38",
-                                        "visible": false,
                                         "description": "Coccidioidomycosis"
                                     }
                                 ]
@@ -3676,7 +3586,6 @@
                                     {
                                         "key": "B39",
                                         "name": "B39",
-                                        "visible": false,
                                         "description": "Histoplasmosis"
                                     }
                                 ]
@@ -3724,7 +3633,6 @@
                                     {
                                         "key": "B40",
                                         "name": "B40",
-                                        "visible": false,
                                         "description": "Blastomycosis"
                                     }
                                 ]
@@ -3757,7 +3665,6 @@
                                     {
                                         "key": "B41",
                                         "name": "B41",
-                                        "visible": false,
                                         "description": "Paracoccidioidomycosis"
                                     }
                                 ]
@@ -3790,7 +3697,6 @@
                                     {
                                         "key": "B42",
                                         "name": "B42",
-                                        "visible": false,
                                         "description": "Sporotrichosis"
                                     }
                                 ]
@@ -3828,7 +3734,6 @@
                                     {
                                         "key": "B43",
                                         "name": "B43",
-                                        "visible": false,
                                         "description": "Chromomycosis and phaeomycotic abscess"
                                     }
                                 ]
@@ -3871,7 +3776,6 @@
                                     {
                                         "key": "B44",
                                         "name": "B44",
-                                        "visible": false,
                                         "description": "Aspergillosis"
                                     }
                                 ]
@@ -3919,7 +3823,6 @@
                                     {
                                         "key": "B45",
                                         "name": "B45",
-                                        "visible": false,
                                         "description": "Cryptococcosis"
                                     }
                                 ]
@@ -3972,7 +3875,6 @@
                                     {
                                         "key": "B46",
                                         "name": "B46",
-                                        "visible": false,
                                         "description": "Zygomycosis"
                                     }
                                 ]
@@ -4000,7 +3902,6 @@
                                     {
                                         "key": "B47",
                                         "name": "B47",
-                                        "visible": false,
                                         "description": "Mycetoma"
                                     }
                                 ]
@@ -4048,7 +3949,6 @@
                                     {
                                         "key": "B48",
                                         "name": "B48",
-                                        "visible": false,
                                         "description": "Other mycoses, not elsewhere classified"
                                     }
                                 ]
@@ -4081,7 +3981,6 @@
                                     {
                                         "key": "B50",
                                         "name": "B50",
-                                        "visible": false,
                                         "description": "Plasmodium falciparum malaria"
                                     }
                                 ]
@@ -4109,7 +4008,6 @@
                                     {
                                         "key": "B51",
                                         "name": "B51",
-                                        "visible": false,
                                         "description": "Plasmodium vivax malaria"
                                     }
                                 ]
@@ -4137,7 +4035,6 @@
                                     {
                                         "key": "B52",
                                         "name": "B52",
-                                        "visible": false,
                                         "description": "Plasmodium malariae malaria"
                                     }
                                 ]
@@ -4165,7 +4062,6 @@
                                     {
                                         "key": "B53",
                                         "name": "B53",
-                                        "visible": false,
                                         "description": "Other parasitologically confirmed malaria"
                                     }
                                 ]
@@ -4203,7 +4099,6 @@
                                     {
                                         "key": "B55",
                                         "name": "B55",
-                                        "visible": false,
                                         "description": "Leishmaniasis"
                                     }
                                 ]
@@ -4231,7 +4126,6 @@
                                     {
                                         "key": "B56",
                                         "name": "B56",
-                                        "visible": false,
                                         "description": "African trypanosomiasis"
                                     }
                                 ]
@@ -4269,7 +4163,6 @@
                                     {
                                         "key": "B57",
                                         "name": "B57",
-                                        "visible": false,
                                         "description": "Chagas disease"
                                     }
                                 ]
@@ -4292,7 +4185,6 @@
                                     {
                                         "key": "B58",
                                         "name": "B58",
-                                        "visible": false,
                                         "description": "Toxoplasmosis"
                                     }
                                 ]
@@ -4325,7 +4217,6 @@
                                     {
                                         "key": "B60",
                                         "name": "B60",
-                                        "visible": false,
                                         "description": "Other protozoal diseases, not elsewhere classified"
                                     }
                                 ]
@@ -4373,7 +4264,6 @@
                                     {
                                         "key": "B65",
                                         "name": "B65",
-                                        "visible": false,
                                         "description": "Schistosomiasis [bilharziasis]"
                                     }
                                 ]
@@ -4426,7 +4316,6 @@
                                     {
                                         "key": "B66",
                                         "name": "B66",
-                                        "visible": false,
                                         "description": "Other fluke infections"
                                     }
                                 ]
@@ -4489,7 +4378,6 @@
                                     {
                                         "key": "B67",
                                         "name": "B67",
-                                        "visible": false,
                                         "description": "Echinococcosis"
                                     }
                                 ]
@@ -4517,7 +4405,6 @@
                                     {
                                         "key": "B68",
                                         "name": "B68",
-                                        "visible": false,
                                         "description": "Taeniasis"
                                     }
                                 ]
@@ -4550,7 +4437,6 @@
                                     {
                                         "key": "B69",
                                         "name": "B69",
-                                        "visible": false,
                                         "description": "Cysticercosis"
                                     }
                                 ]
@@ -4573,7 +4459,6 @@
                                     {
                                         "key": "B70",
                                         "name": "B70",
-                                        "visible": false,
                                         "description": "Diphyllobothriasis and sparganosis"
                                     }
                                 ]
@@ -4606,7 +4491,6 @@
                                     {
                                         "key": "B71",
                                         "name": "B71",
-                                        "visible": false,
                                         "description": "Other cestode infections"
                                     }
                                 ]
@@ -4664,7 +4548,6 @@
                                     {
                                         "key": "B74",
                                         "name": "B74",
-                                        "visible": false,
                                         "description": "Filariasis"
                                     }
                                 ]
@@ -4702,7 +4585,6 @@
                                     {
                                         "key": "B76",
                                         "name": "B76",
-                                        "visible": false,
                                         "description": "Hookworm diseases"
                                     }
                                 ]
@@ -4730,7 +4612,6 @@
                                     {
                                         "key": "B77",
                                         "name": "B77",
-                                        "visible": false,
                                         "description": "Ascariasis"
                                     }
                                 ]
@@ -4763,7 +4644,6 @@
                                     {
                                         "key": "B78",
                                         "name": "B78",
-                                        "visible": false,
                                         "description": "Strongyloidiasis"
                                     }
                                 ]
@@ -4816,7 +4696,6 @@
                                     {
                                         "key": "B81",
                                         "name": "B81",
-                                        "visible": false,
                                         "description": "Other intestinal helminthiases, not elsewhere classified"
                                     }
                                 ]
@@ -4839,7 +4718,6 @@
                                     {
                                         "key": "B82",
                                         "name": "B82",
-                                        "visible": false,
                                         "description": "Unspecified intestinal parasitism"
                                     }
                                 ]
@@ -4887,7 +4765,6 @@
                                     {
                                         "key": "B83",
                                         "name": "B83",
-                                        "visible": false,
                                         "description": "Other helminthiases"
                                     }
                                 ]
@@ -4925,7 +4802,6 @@
                                     {
                                         "key": "B85",
                                         "name": "B85",
-                                        "visible": false,
                                         "description": "Pediculosis and phthiriasis"
                                     }
                                 ]
@@ -4978,7 +4854,6 @@
                                     {
                                         "key": "B87",
                                         "name": "B87",
-                                        "visible": false,
                                         "description": "Myiasis"
                                     }
                                 ]
@@ -5021,7 +4896,6 @@
                                     {
                                         "key": "B88",
                                         "name": "B88",
-                                        "visible": false,
                                         "description": "Other infestations"
                                     }
                                 ]
@@ -5064,7 +4938,6 @@
                                     {
                                         "key": "B90",
                                         "name": "B90",
-                                        "visible": false,
                                         "description": "Sequelae of tuberculosis"
                                     }
                                 ]
@@ -5112,7 +4985,6 @@
                                     {
                                         "key": "B94",
                                         "name": "B94",
-                                        "visible": false,
                                         "description": "Sequelae of other and unspecified infectious and parasitic diseases"
                                     }
                                 ]
@@ -5182,7 +5054,6 @@
                                     {
                                         "key": "C00",
                                         "name": "C00",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of lip"
                                     }
                                 ]
@@ -5235,7 +5106,6 @@
                                     {
                                         "key": "C02",
                                         "name": "C02",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and unspecified parts of tongue"
                                     }
                                 ]
@@ -5263,7 +5133,6 @@
                                     {
                                         "key": "C03",
                                         "name": "C03",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of gum"
                                     }
                                 ]
@@ -5296,7 +5165,6 @@
                                     {
                                         "key": "C04",
                                         "name": "C04",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of floor of mouth"
                                     }
                                 ]
@@ -5334,7 +5202,6 @@
                                     {
                                         "key": "C05",
                                         "name": "C05",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of palate"
                                     }
                                 ]
@@ -5372,7 +5239,6 @@
                                     {
                                         "key": "C06",
                                         "name": "C06",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and unspecified parts of mouth"
                                     }
                                 ]
@@ -5410,7 +5276,6 @@
                                     {
                                         "key": "C08",
                                         "name": "C08",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and unspecified major salivary glands"
                                     }
                                 ]
@@ -5443,7 +5308,6 @@
                                     {
                                         "key": "C09",
                                         "name": "C09",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of tonsil"
                                     }
                                 ]
@@ -5491,7 +5355,6 @@
                                     {
                                         "key": "C10",
                                         "name": "C10",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of oropharynx"
                                     }
                                 ]
@@ -5534,7 +5397,6 @@
                                     {
                                         "key": "C11",
                                         "name": "C11",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of nasopharynx"
                                     }
                                 ]
@@ -5577,7 +5439,6 @@
                                     {
                                         "key": "C13",
                                         "name": "C13",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of hypopharynx"
                                     }
                                 ]
@@ -5605,7 +5466,6 @@
                                     {
                                         "key": "C14",
                                         "name": "C14",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and ill-defined sites in the lip, oral cavity and pharynx"
                                     }
                                 ]
@@ -5658,7 +5518,6 @@
                                     {
                                         "key": "C15",
                                         "name": "C15",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of oesophagus"
                                     }
                                 ]
@@ -5716,7 +5575,6 @@
                                     {
                                         "key": "C16",
                                         "name": "C16",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of stomach"
                                     }
                                 ]
@@ -5759,7 +5617,6 @@
                                     {
                                         "key": "C17",
                                         "name": "C17",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of small intestine"
                                     }
                                 ]
@@ -5822,7 +5679,6 @@
                                     {
                                         "key": "C18",
                                         "name": "C18",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of colon"
                                     }
                                 ]
@@ -5865,7 +5721,6 @@
                                     {
                                         "key": "C21",
                                         "name": "C21",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of anus and anal canal"
                                     }
                                 ]
@@ -5913,7 +5768,6 @@
                                     {
                                         "key": "C22",
                                         "name": "C22",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of liver and intrahepatic bile ducts"
                                     }
                                 ]
@@ -5951,7 +5805,6 @@
                                     {
                                         "key": "C24",
                                         "name": "C24",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and unspecified parts of biliary tract"
                                     }
                                 ]
@@ -6004,7 +5857,6 @@
                                     {
                                         "key": "C25",
                                         "name": "C25",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of pancreas"
                                     }
                                 ]
@@ -6037,7 +5889,6 @@
                                     {
                                         "key": "C26",
                                         "name": "C26",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and ill-defined digestive organs"
                                     }
                                 ]
@@ -6060,7 +5911,6 @@
                                     {
                                         "key": "C30",
                                         "name": "C30",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of nasal cavity and middle ear"
                                     }
                                 ]
@@ -6103,7 +5953,6 @@
                                     {
                                         "key": "C31",
                                         "name": "C31",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of accessory sinuses"
                                     }
                                 ]
@@ -6146,7 +5995,6 @@
                                     {
                                         "key": "C32",
                                         "name": "C32",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of larynx"
                                     }
                                 ]
@@ -6194,7 +6042,6 @@
                                     {
                                         "key": "C34",
                                         "name": "C34",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of bronchus and lung"
                                     }
                                 ]
@@ -6242,7 +6089,6 @@
                                     {
                                         "key": "C38",
                                         "name": "C38",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of heart, mediastinum and pleura"
                                     }
                                 ]
@@ -6270,7 +6116,6 @@
                                     {
                                         "key": "C39",
                                         "name": "C39",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and ill-defined sites in the respiratory system and intrathoracic organs"
                                     }
                                 ]
@@ -6313,7 +6158,6 @@
                                     {
                                         "key": "C40",
                                         "name": "C40",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of bone and articular cartilage of limbs"
                                     }
                                 ]
@@ -6361,7 +6205,6 @@
                                     {
                                         "key": "C41",
                                         "name": "C41",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of bone and articular cartilage of other and unspecified sites"
                                     }
                                 ]
@@ -6424,7 +6267,6 @@
                                     {
                                         "key": "C43",
                                         "name": "C43",
-                                        "visible": false,
                                         "description": "Malignant melanoma of skin"
                                     }
                                 ]
@@ -6487,7 +6329,6 @@
                                     {
                                         "key": "C44",
                                         "name": "C44",
-                                        "visible": false,
                                         "description": "Other malignant neoplasms of skin"
                                     }
                                 ]
@@ -6525,7 +6366,6 @@
                                     {
                                         "key": "C45",
                                         "name": "C45",
-                                        "visible": false,
                                         "description": "Mesothelioma"
                                     }
                                 ]
@@ -6573,7 +6413,6 @@
                                     {
                                         "key": "C46",
                                         "name": "C46",
-                                        "visible": false,
                                         "description": "Kaposi sarcoma"
                                     }
                                 ]
@@ -6631,7 +6470,6 @@
                                     {
                                         "key": "C47",
                                         "name": "C47",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of peripheral nerves and autonomic nervous system"
                                     }
                                 ]
@@ -6664,7 +6502,6 @@
                                     {
                                         "key": "C48",
                                         "name": "C48",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of retroperitoneum and peritoneum"
                                     }
                                 ]
@@ -6722,7 +6559,6 @@
                                     {
                                         "key": "C49",
                                         "name": "C49",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other connective and soft tissue"
                                     }
                                 ]
@@ -6780,7 +6616,6 @@
                                     {
                                         "key": "C50",
                                         "name": "C50",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of breast"
                                     }
                                 ]
@@ -6818,7 +6653,6 @@
                                     {
                                         "key": "C51",
                                         "name": "C51",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of vulva"
                                     }
                                 ]
@@ -6856,7 +6690,6 @@
                                     {
                                         "key": "C53",
                                         "name": "C53",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of cervix uteri"
                                     }
                                 ]
@@ -6899,7 +6732,6 @@
                                     {
                                         "key": "C54",
                                         "name": "C54",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of corpus uteri"
                                     }
                                 ]
@@ -6962,7 +6794,6 @@
                                     {
                                         "key": "C57",
                                         "name": "C57",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and unspecified female genital organs"
                                     }
                                 ]
@@ -7005,7 +6836,6 @@
                                     {
                                         "key": "C60",
                                         "name": "C60",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of penis"
                                     }
                                 ]
@@ -7038,7 +6868,6 @@
                                     {
                                         "key": "C62",
                                         "name": "C62",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of testis"
                                     }
                                 ]
@@ -7081,7 +6910,6 @@
                                     {
                                         "key": "C63",
                                         "name": "C63",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and unspecified male genital organs"
                                     }
                                 ]
@@ -7159,7 +6987,6 @@
                                     {
                                         "key": "C67",
                                         "name": "C67",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of bladder"
                                     }
                                 ]
@@ -7192,7 +7019,6 @@
                                     {
                                         "key": "C68",
                                         "name": "C68",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and unspecified urinary organs"
                                     }
                                 ]
@@ -7250,7 +7076,6 @@
                                     {
                                         "key": "C69",
                                         "name": "C69",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of eye and adnexa"
                                     }
                                 ]
@@ -7278,7 +7103,6 @@
                                     {
                                         "key": "C70",
                                         "name": "C70",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of meninges"
                                     }
                                 ]
@@ -7341,7 +7165,6 @@
                                     {
                                         "key": "C71",
                                         "name": "C71",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of brain"
                                     }
                                 ]
@@ -7394,7 +7217,6 @@
                                     {
                                         "key": "C72",
                                         "name": "C72",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of spinal cord, cranial nerves and other parts of central nervous system"
                                     }
                                 ]
@@ -7427,7 +7249,6 @@
                                     {
                                         "key": "C74",
                                         "name": "C74",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of adrenal gland"
                                     }
                                 ]
@@ -7480,7 +7301,6 @@
                                     {
                                         "key": "C75",
                                         "name": "C75",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other endocrine glands and related structures"
                                     }
                                 ]
@@ -7533,7 +7353,6 @@
                                     {
                                         "key": "C76",
                                         "name": "C76",
-                                        "visible": false,
                                         "description": "Malignant neoplasm of other and ill-defined sites"
                                     }
                                 ]
@@ -7586,7 +7405,6 @@
                                     {
                                         "key": "C77",
                                         "name": "C77",
-                                        "visible": false,
                                         "description": "Secondary and unspecified malignant neoplasm of lymph nodes"
                                     }
                                 ]
@@ -7644,7 +7462,6 @@
                                     {
                                         "key": "C78",
                                         "name": "C78",
-                                        "visible": false,
                                         "description": "Secondary malignant neoplasm of respiratory and digestive organs"
                                     }
                                 ]
@@ -7707,7 +7524,6 @@
                                     {
                                         "key": "C79",
                                         "name": "C79",
-                                        "visible": false,
                                         "description": "Secondary malignant neoplasm of other and unspecified sites"
                                     }
                                 ]
@@ -7730,7 +7546,6 @@
                                     {
                                         "key": "C80",
                                         "name": "C80",
-                                        "visible": false,
                                         "description": "Malignant neoplasm, without specification of site"
                                     }
                                 ]
@@ -7778,7 +7593,6 @@
                                     {
                                         "key": "C81",
                                         "name": "C81",
-                                        "visible": false,
                                         "description": "Hodgkin lymphoma"
                                     }
                                 ]
@@ -7836,7 +7650,6 @@
                                     {
                                         "key": "C82",
                                         "name": "C82",
-                                        "visible": false,
                                         "description": "Follicular lymphoma"
                                     }
                                 ]
@@ -7884,7 +7697,6 @@
                                     {
                                         "key": "C83",
                                         "name": "C83",
-                                        "visible": false,
                                         "description": "Non-follicular lymphoma"
                                     }
                                 ]
@@ -7937,7 +7749,6 @@
                                     {
                                         "key": "C84",
                                         "name": "C84",
-                                        "visible": false,
                                         "description": "Mature T/NK-cell lymphomas"
                                     }
                                 ]
@@ -7970,7 +7781,6 @@
                                     {
                                         "key": "C85",
                                         "name": "C85",
-                                        "visible": false,
                                         "description": "Other and unspecified types of non-Hodgkin lymphoma"
                                     }
                                 ]
@@ -8018,7 +7828,6 @@
                                     {
                                         "key": "C86",
                                         "name": "C86",
-                                        "visible": false,
                                         "description": "Other specified types of T/NK-cell lymphoma"
                                     }
                                 ]
@@ -8061,7 +7870,6 @@
                                     {
                                         "key": "C88",
                                         "name": "C88",
-                                        "visible": false,
                                         "description": "Malignant immunoproliferative diseases"
                                     }
                                 ]
@@ -8094,7 +7902,6 @@
                                     {
                                         "key": "C90",
                                         "name": "C90",
-                                        "visible": false,
                                         "description": "Multiple myeloma and malignant plasma cell neoplasms"
                                     }
                                 ]
@@ -8152,7 +7959,6 @@
                                     {
                                         "key": "C91",
                                         "name": "C91",
-                                        "visible": false,
                                         "description": "Lymphoid leukaemia"
                                     }
                                 ]
@@ -8215,7 +8021,6 @@
                                     {
                                         "key": "C92",
                                         "name": "C92",
-                                        "visible": false,
                                         "description": "Myeloid leukaemia"
                                     }
                                 ]
@@ -8253,7 +8058,6 @@
                                     {
                                         "key": "C93",
                                         "name": "C93",
-                                        "visible": false,
                                         "description": "Monocytic leukaemia"
                                     }
                                 ]
@@ -8296,7 +8100,6 @@
                                     {
                                         "key": "C94",
                                         "name": "C94",
-                                        "visible": false,
                                         "description": "Other leukaemias of specified cell type"
                                     }
                                 ]
@@ -8329,7 +8132,6 @@
                                     {
                                         "key": "C95",
                                         "name": "C95",
-                                        "visible": false,
                                         "description": "Leukaemia of unspecified cell type"
                                     }
                                 ]
@@ -8382,7 +8184,6 @@
                                     {
                                         "key": "C96",
                                         "name": "C96",
-                                        "visible": false,
                                         "description": "Other and unspecified malignant neoplasms of lymphoid, haematopoietic and related tissue"
                                     }
                                 ]
@@ -8417,7 +8218,6 @@
                                     {
                                         "key": "D00",
                                         "name": "D00",
-                                        "visible": false,
                                         "description": "Carcinoma in situ of oral cavity, oesophagus and stomach"
                                     }
                                 ]
@@ -8470,7 +8270,6 @@
                                     {
                                         "key": "D01",
                                         "name": "D01",
-                                        "visible": false,
                                         "description": "Carcinoma in situ of other and unspecified digestive organs"
                                     }
                                 ]
@@ -8508,7 +8307,6 @@
                                     {
                                         "key": "D02",
                                         "name": "D02",
-                                        "visible": false,
                                         "description": "Carcinoma in situ of middle ear and respiratory system"
                                     }
                                 ]
@@ -8571,7 +8369,6 @@
                                     {
                                         "key": "D03",
                                         "name": "D03",
-                                        "visible": false,
                                         "description": "Melanoma in situ"
                                     }
                                 ]
@@ -8634,7 +8431,6 @@
                                     {
                                         "key": "D04",
                                         "name": "D04",
-                                        "visible": false,
                                         "description": "Carcinoma in situ of skin"
                                     }
                                 ]
@@ -8667,7 +8463,6 @@
                                     {
                                         "key": "D05",
                                         "name": "D05",
-                                        "visible": false,
                                         "description": "Carcinoma in situ of breast"
                                     }
                                 ]
@@ -8700,7 +8495,6 @@
                                     {
                                         "key": "D06",
                                         "name": "D06",
-                                        "visible": false,
                                         "description": "Carcinoma in situ of cervix uteri"
                                     }
                                 ]
@@ -8748,7 +8542,6 @@
                                     {
                                         "key": "D07",
                                         "name": "D07",
-                                        "visible": false,
                                         "description": "Carcinoma in situ of other and unspecified genital organs"
                                     }
                                 ]
@@ -8791,7 +8584,6 @@
                                     {
                                         "key": "D09",
                                         "name": "D09",
-                                        "visible": false,
                                         "description": "Carcinoma in situ of other and unspecified sites"
                                     }
                                 ]
@@ -8849,7 +8641,6 @@
                                     {
                                         "key": "D10",
                                         "name": "D10",
-                                        "visible": false,
                                         "description": "Benign neoplasm of mouth and pharynx"
                                     }
                                 ]
@@ -8877,7 +8668,6 @@
                                     {
                                         "key": "D11",
                                         "name": "D11",
-                                        "visible": false,
                                         "description": "Benign neoplasm of major salivary glands"
                                     }
                                 ]
@@ -8940,7 +8730,6 @@
                                     {
                                         "key": "D12",
                                         "name": "D12",
-                                        "visible": false,
                                         "description": "Benign neoplasm of colon, rectum, anus and anal canal"
                                     }
                                 ]
@@ -8998,7 +8787,6 @@
                                     {
                                         "key": "D13",
                                         "name": "D13",
-                                        "visible": false,
                                         "description": "Benign neoplasm of other and ill-defined parts of digestive system"
                                     }
                                 ]
@@ -9036,7 +8824,6 @@
                                     {
                                         "key": "D14",
                                         "name": "D14",
-                                        "visible": false,
                                         "description": "Benign neoplasm of middle ear and respiratory system"
                                     }
                                 ]
@@ -9074,7 +8861,6 @@
                                     {
                                         "key": "D15",
                                         "name": "D15",
-                                        "visible": false,
                                         "description": "Benign neoplasm of other and unspecified intrathoracic organs"
                                     }
                                 ]
@@ -9137,7 +8923,6 @@
                                     {
                                         "key": "D16",
                                         "name": "D16",
-                                        "visible": false,
                                         "description": "Benign neoplasm of bone and articular cartilage"
                                     }
                                 ]
@@ -9195,7 +8980,6 @@
                                     {
                                         "key": "D17",
                                         "name": "D17",
-                                        "visible": false,
                                         "description": "Benign lipomatous neoplasm"
                                     }
                                 ]
@@ -9218,7 +9002,6 @@
                                     {
                                         "key": "D18",
                                         "name": "D18",
-                                        "visible": false,
                                         "description": "Haemangioma and lymphangioma, any site"
                                     }
                                 ]
@@ -9251,7 +9034,6 @@
                                     {
                                         "key": "D19",
                                         "name": "D19",
-                                        "visible": false,
                                         "description": "Benign neoplasm of mesothelial tissue"
                                     }
                                 ]
@@ -9274,7 +9056,6 @@
                                     {
                                         "key": "D20",
                                         "name": "D20",
-                                        "visible": false,
                                         "description": "Benign neoplasm of soft tissue of retroperitoneum and peritoneum"
                                     }
                                 ]
@@ -9327,7 +9108,6 @@
                                     {
                                         "key": "D21",
                                         "name": "D21",
-                                        "visible": false,
                                         "description": "Other benign neoplasms of connective and other soft tissue"
                                     }
                                 ]
@@ -9385,7 +9165,6 @@
                                     {
                                         "key": "D22",
                                         "name": "D22",
-                                        "visible": false,
                                         "description": "Melanocytic naevi"
                                     }
                                 ]
@@ -9443,7 +9222,6 @@
                                     {
                                         "key": "D23",
                                         "name": "D23",
-                                        "visible": false,
                                         "description": "Other benign neoplasms of skin"
                                     }
                                 ]
@@ -9481,7 +9259,6 @@
                                     {
                                         "key": "D25",
                                         "name": "D25",
-                                        "visible": false,
                                         "description": "Leiomyoma of uterus"
                                     }
                                 ]
@@ -9514,7 +9291,6 @@
                                     {
                                         "key": "D26",
                                         "name": "D26",
-                                        "visible": false,
                                         "description": "Other benign neoplasms of uterus"
                                     }
                                 ]
@@ -9557,7 +9333,6 @@
                                     {
                                         "key": "D28",
                                         "name": "D28",
-                                        "visible": false,
                                         "description": "Benign neoplasm of other and unspecified female genital organs"
                                     }
                                 ]
@@ -9605,7 +9380,6 @@
                                     {
                                         "key": "D29",
                                         "name": "D29",
-                                        "visible": false,
                                         "description": "Benign neoplasm of male genital organs"
                                     }
                                 ]
@@ -9653,7 +9427,6 @@
                                     {
                                         "key": "D30",
                                         "name": "D30",
-                                        "visible": false,
                                         "description": "Benign neoplasm of urinary organs"
                                     }
                                 ]
@@ -9706,7 +9479,6 @@
                                     {
                                         "key": "D31",
                                         "name": "D31",
-                                        "visible": false,
                                         "description": "Benign neoplasm of eye and adnexa"
                                     }
                                 ]
@@ -9734,7 +9506,6 @@
                                     {
                                         "key": "D32",
                                         "name": "D32",
-                                        "visible": false,
                                         "description": "Benign neoplasm of meninges"
                                     }
                                 ]
@@ -9782,7 +9553,6 @@
                                     {
                                         "key": "D33",
                                         "name": "D33",
-                                        "visible": false,
                                         "description": "Benign neoplasm of brain and other parts of central nervous system"
                                     }
                                 ]
@@ -9850,7 +9620,6 @@
                                     {
                                         "key": "D35",
                                         "name": "D35",
-                                        "visible": false,
                                         "description": "Benign neoplasm of other and unspecified endocrine glands"
                                     }
                                 ]
@@ -9883,7 +9652,6 @@
                                     {
                                         "key": "D36",
                                         "name": "D36",
-                                        "visible": false,
                                         "description": "Benign neoplasm of other and unspecified sites"
                                     }
                                 ]
@@ -9941,7 +9709,6 @@
                                     {
                                         "key": "D37",
                                         "name": "D37",
-                                        "visible": false,
                                         "description": "Neoplasm of uncertain or unknown behaviour of oral cavity and digestive organs"
                                     }
                                 ]
@@ -9989,7 +9756,6 @@
                                     {
                                         "key": "D38",
                                         "name": "D38",
-                                        "visible": false,
                                         "description": "Neoplasm of uncertain or unknown behaviour of middle ear and respiratory and intrathoracic organs"
                                     }
                                 ]
@@ -10027,7 +9793,6 @@
                                     {
                                         "key": "D39",
                                         "name": "D39",
-                                        "visible": false,
                                         "description": "Neoplasm of uncertain or unknown behaviour of female genital organs"
                                     }
                                 ]
@@ -10060,7 +9825,6 @@
                                     {
                                         "key": "D40",
                                         "name": "D40",
-                                        "visible": false,
                                         "description": "Neoplasm of uncertain or unknown behaviour of male genital organs"
                                     }
                                 ]
@@ -10108,7 +9872,6 @@
                                     {
                                         "key": "D41",
                                         "name": "D41",
-                                        "visible": false,
                                         "description": "Neoplasm of uncertain or unknown behaviour of urinary organs"
                                     }
                                 ]
@@ -10136,7 +9899,6 @@
                                     {
                                         "key": "D42",
                                         "name": "D42",
-                                        "visible": false,
                                         "description": "Neoplasm of uncertain or unknown behaviour of meninges"
                                     }
                                 ]
@@ -10184,7 +9946,6 @@
                                     {
                                         "key": "D43",
                                         "name": "D43",
-                                        "visible": false,
                                         "description": "Neoplasm of uncertain or unknown behaviour of brain and central nervous system"
                                     }
                                 ]
@@ -10247,7 +10008,6 @@
                                     {
                                         "key": "D44",
                                         "name": "D44",
-                                        "visible": false,
                                         "description": "Neoplasm of uncertain or unknown behaviour of endocrine glands"
                                     }
                                 ]
@@ -10305,7 +10065,6 @@
                                     {
                                         "key": "D46",
                                         "name": "D46",
-                                        "visible": false,
                                         "description": "Myelodysplastic syndromes"
                                     }
                                 ]
@@ -10358,7 +10117,6 @@
                                     {
                                         "key": "D47",
                                         "name": "D47",
-                                        "visible": false,
                                         "description": "Other neoplasms of uncertain or unknown behaviour of lymphoid, haematopoietic and related tissue"
                                     }
                                 ]
@@ -10416,7 +10174,6 @@
                                     {
                                         "key": "D48",
                                         "name": "D48",
-                                        "visible": false,
                                         "description": "Neoplasm of uncertain or unknown behaviour of other and unspecified sites"
                                     }
                                 ]
@@ -10449,7 +10206,6 @@
                                     {
                                         "key": "D50",
                                         "name": "D50",
-                                        "visible": false,
                                         "description": "Iron deficiency anaemia"
                                     }
                                 ]
@@ -10492,7 +10248,6 @@
                                     {
                                         "key": "D51",
                                         "name": "D51",
-                                        "visible": false,
                                         "description": "Vitamin B 12 deficiency anaemia"
                                     }
                                 ]
@@ -10525,7 +10280,6 @@
                                     {
                                         "key": "D52",
                                         "name": "D52",
-                                        "visible": false,
                                         "description": "Folate deficiency anaemia"
                                     }
                                 ]
@@ -10563,7 +10317,6 @@
                                     {
                                         "key": "D53",
                                         "name": "D53",
-                                        "visible": false,
                                         "description": "Other nutritional anaemias"
                                     }
                                 ]
@@ -10606,7 +10359,6 @@
                                     {
                                         "key": "D55",
                                         "name": "D55",
-                                        "visible": false,
                                         "description": "Anaemia due to enzyme disorders"
                                     }
                                 ]
@@ -10654,7 +10406,6 @@
                                     {
                                         "key": "D56",
                                         "name": "D56",
-                                        "visible": false,
                                         "description": "Thalassaemia"
                                     }
                                 ]
@@ -10692,7 +10443,6 @@
                                     {
                                         "key": "D57",
                                         "name": "D57",
-                                        "visible": false,
                                         "description": "Sickle-cell disorders"
                                     }
                                 ]
@@ -10730,7 +10480,6 @@
                                     {
                                         "key": "D58",
                                         "name": "D58",
-                                        "visible": false,
                                         "description": "Other hereditary haemolytic anaemias"
                                     }
                                 ]
@@ -10788,7 +10537,6 @@
                                     {
                                         "key": "D59",
                                         "name": "D59",
-                                        "visible": false,
                                         "description": "Acquired haemolytic anaemia"
                                     }
                                 ]
@@ -10821,7 +10569,6 @@
                                     {
                                         "key": "D60",
                                         "name": "D60",
-                                        "visible": false,
                                         "description": "Acquired pure red cell aplasia [erythroblastopenia]"
                                     }
                                 ]
@@ -10864,7 +10611,6 @@
                                     {
                                         "key": "D61",
                                         "name": "D61",
-                                        "visible": false,
                                         "description": "Other aplastic anaemias"
                                     }
                                 ]
@@ -10917,7 +10663,6 @@
                                     {
                                         "key": "D64",
                                         "name": "D64",
-                                        "visible": false,
                                         "description": "Other anaemias"
                                     }
                                 ]
@@ -10990,7 +10735,6 @@
                                     {
                                         "key": "D68",
                                         "name": "D68",
-                                        "visible": false,
                                         "description": "Other coagulation defects"
                                     }
                                 ]
@@ -11048,7 +10792,6 @@
                                     {
                                         "key": "D69",
                                         "name": "D69",
-                                        "visible": false,
                                         "description": "Purpura and other haemorrhagic conditions"
                                     }
                                 ]
@@ -11091,7 +10834,6 @@
                                     {
                                         "key": "D72",
                                         "name": "D72",
-                                        "visible": false,
                                         "description": "Other disorders of white blood cells"
                                     }
                                 ]
@@ -11144,7 +10886,6 @@
                                     {
                                         "key": "D73",
                                         "name": "D73",
-                                        "visible": false,
                                         "description": "Diseases of spleen"
                                     }
                                 ]
@@ -11172,7 +10913,6 @@
                                     {
                                         "key": "D74",
                                         "name": "D74",
-                                        "visible": false,
                                         "description": "Methaemoglobinaemia"
                                     }
                                 ]
@@ -11205,7 +10945,6 @@
                                     {
                                         "key": "D75",
                                         "name": "D75",
-                                        "visible": false,
                                         "description": "Other diseases of blood and blood-forming organs"
                                     }
                                 ]
@@ -11233,7 +10972,6 @@
                                     {
                                         "key": "D76",
                                         "name": "D76",
-                                        "visible": false,
                                         "description": "Other specified diseases with participation of lymphoreticular and reticulohistiocytic tissue"
                                     }
                                 ]
@@ -11296,7 +11034,6 @@
                                     {
                                         "key": "D80",
                                         "name": "D80",
-                                        "visible": false,
                                         "description": "Immunodeficiency with predominantly antibody defects"
                                     }
                                 ]
@@ -11359,7 +11096,6 @@
                                     {
                                         "key": "D81",
                                         "name": "D81",
-                                        "visible": false,
                                         "description": "Combined immunodeficiencies"
                                     }
                                 ]
@@ -11407,7 +11143,6 @@
                                     {
                                         "key": "D82",
                                         "name": "D82",
-                                        "visible": false,
                                         "description": "Immunodeficiency associated with other major defects"
                                     }
                                 ]
@@ -11445,7 +11180,6 @@
                                     {
                                         "key": "D83",
                                         "name": "D83",
-                                        "visible": false,
                                         "description": "Common variable immunodeficiency"
                                     }
                                 ]
@@ -11478,7 +11212,6 @@
                                     {
                                         "key": "D84",
                                         "name": "D84",
-                                        "visible": false,
                                         "description": "Other immunodeficiencies"
                                     }
                                 ]
@@ -11521,7 +11254,6 @@
                                     {
                                         "key": "D86",
                                         "name": "D86",
-                                        "visible": false,
                                         "description": "Sarcoidosis"
                                     }
                                 ]
@@ -11564,7 +11296,6 @@
                                     {
                                         "key": "D89",
                                         "name": "D89",
-                                        "visible": false,
                                         "description": "Other disorders involving the immune mechanism, not elsewhere classified"
                                     }
                                 ]
@@ -11604,7 +11335,6 @@
                                     {
                                         "key": "E00",
                                         "name": "E00",
-                                        "visible": false,
                                         "description": "Congenital iodine-deficiency syndrome"
                                     }
                                 ]
@@ -11637,7 +11367,6 @@
                                     {
                                         "key": "E01",
                                         "name": "E01",
-                                        "visible": false,
                                         "description": "Iodine-deficiency-related thyroid disorders and allied conditions"
                                     }
                                 ]
@@ -11695,7 +11424,6 @@
                                     {
                                         "key": "E03",
                                         "name": "E03",
-                                        "visible": false,
                                         "description": "Other hypothyroidism"
                                     }
                                 ]
@@ -11733,7 +11461,6 @@
                                     {
                                         "key": "E04",
                                         "name": "E04",
-                                        "visible": false,
                                         "description": "Other nontoxic goitre"
                                     }
                                 ]
@@ -11786,7 +11513,6 @@
                                     {
                                         "key": "E05",
                                         "name": "E05",
-                                        "visible": false,
                                         "description": "Thyrotoxicosis [hyperthyroidism]"
                                     }
                                 ]
@@ -11834,7 +11560,6 @@
                                     {
                                         "key": "E06",
                                         "name": "E06",
-                                        "visible": false,
                                         "description": "Thyroiditis"
                                     }
                                 ]
@@ -11867,7 +11592,6 @@
                                     {
                                         "key": "E07",
                                         "name": "E07",
-                                        "visible": false,
                                         "description": "Other disorders of thyroid"
                                     }
                                 ]
@@ -11945,7 +11669,6 @@
                                     {
                                         "key": "E16",
                                         "name": "E16",
-                                        "visible": false,
                                         "description": "Other disorders of pancreatic internal secretion"
                                     }
                                 ]
@@ -11978,7 +11701,6 @@
                                     {
                                         "key": "E20",
                                         "name": "E20",
-                                        "visible": false,
                                         "description": "Hypoparathyroidism"
                                     }
                                 ]
@@ -12021,7 +11743,6 @@
                                     {
                                         "key": "E21",
                                         "name": "E21",
-                                        "visible": false,
                                         "description": "Hyperparathyroidism and other disorders of parathyroid gland"
                                     }
                                 ]
@@ -12059,7 +11780,6 @@
                                     {
                                         "key": "E22",
                                         "name": "E22",
-                                        "visible": false,
                                         "description": "Hyperfunction of pituitary gland"
                                     }
                                 ]
@@ -12102,7 +11822,6 @@
                                     {
                                         "key": "E23",
                                         "name": "E23",
-                                        "visible": false,
                                         "description": "Hypofunction and other disorders of pituitary gland"
                                     }
                                 ]
@@ -12150,7 +11869,6 @@
                                     {
                                         "key": "E24",
                                         "name": "E24",
-                                        "visible": false,
                                         "description": "Cushing syndrome"
                                     }
                                 ]
@@ -12178,7 +11896,6 @@
                                     {
                                         "key": "E25",
                                         "name": "E25",
-                                        "visible": false,
                                         "description": "Adrenogenital disorders"
                                     }
                                 ]
@@ -12211,7 +11928,6 @@
                                     {
                                         "key": "E26",
                                         "name": "E26",
-                                        "visible": false,
                                         "description": "Hyperaldosteronism"
                                     }
                                 ]
@@ -12264,7 +11980,6 @@
                                     {
                                         "key": "E27",
                                         "name": "E27",
-                                        "visible": false,
                                         "description": "Other disorders of adrenal gland"
                                     }
                                 ]
@@ -12307,7 +12022,6 @@
                                     {
                                         "key": "E28",
                                         "name": "E28",
-                                        "visible": false,
                                         "description": "Ovarian dysfunction"
                                     }
                                 ]
@@ -12340,7 +12054,6 @@
                                     {
                                         "key": "E29",
                                         "name": "E29",
-                                        "visible": false,
                                         "description": "Testicular dysfunction"
                                     }
                                 ]
@@ -12373,7 +12086,6 @@
                                     {
                                         "key": "E30",
                                         "name": "E30",
-                                        "visible": false,
                                         "description": "Disorders of puberty, not elsewhere classified"
                                     }
                                 ]
@@ -12406,7 +12118,6 @@
                                     {
                                         "key": "E31",
                                         "name": "E31",
-                                        "visible": false,
                                         "description": "Polyglandular dysfunction"
                                     }
                                 ]
@@ -12439,7 +12150,6 @@
                                     {
                                         "key": "E32",
                                         "name": "E32",
-                                        "visible": false,
                                         "description": "Diseases of thymus"
                                     }
                                 ]
@@ -12492,7 +12202,6 @@
                                     {
                                         "key": "E34",
                                         "name": "E34",
-                                        "visible": false,
                                         "description": "Other endocrine disorders"
                                     }
                                 ]
@@ -12535,7 +12244,6 @@
                                     {
                                         "key": "E44",
                                         "name": "E44",
-                                        "visible": false,
                                         "description": "Protein-energy malnutrition of moderate and mild degree"
                                     }
                                 ]
@@ -12608,7 +12316,6 @@
                                     {
                                         "key": "E50",
                                         "name": "E50",
-                                        "visible": false,
                                         "description": "Vitamin A deficiency"
                                     }
                                 ]
@@ -12641,7 +12348,6 @@
                                     {
                                         "key": "E51",
                                         "name": "E51",
-                                        "visible": false,
                                         "description": "Thiamine deficiency"
                                     }
                                 ]
@@ -12679,7 +12385,6 @@
                                     {
                                         "key": "E53",
                                         "name": "E53",
-                                        "visible": false,
                                         "description": "Deficiency of other B group vitamins"
                                     }
                                 ]
@@ -12707,7 +12412,6 @@
                                     {
                                         "key": "E55",
                                         "name": "E55",
-                                        "visible": false,
                                         "description": "Vitamin D deficiency"
                                     }
                                 ]
@@ -12740,7 +12444,6 @@
                                     {
                                         "key": "E56",
                                         "name": "E56",
-                                        "visible": false,
                                         "description": "Other vitamin deficiencies"
                                     }
                                 ]
@@ -12818,7 +12521,6 @@
                                     {
                                         "key": "E61",
                                         "name": "E61",
-                                        "visible": false,
                                         "description": "Deficiency of other nutrient elements"
                                     }
                                 ]
@@ -12851,7 +12553,6 @@
                                     {
                                         "key": "E63",
                                         "name": "E63",
-                                        "visible": false,
                                         "description": "Other nutritional deficiencies"
                                     }
                                 ]
@@ -12894,7 +12595,6 @@
                                     {
                                         "key": "E64",
                                         "name": "E64",
-                                        "visible": false,
                                         "description": "Sequelae of malnutrition and other nutritional deficiencies"
                                     }
                                 ]
@@ -12937,7 +12637,6 @@
                                     {
                                         "key": "E66",
                                         "name": "E66",
-                                        "visible": false,
                                         "description": "Obesity"
                                     }
                                 ]
@@ -12975,7 +12674,6 @@
                                     {
                                         "key": "E67",
                                         "name": "E67",
-                                        "visible": false,
                                         "description": "Other hyperalimentation"
                                     }
                                 ]
@@ -13023,7 +12721,6 @@
                                     {
                                         "key": "E70",
                                         "name": "E70",
-                                        "visible": false,
                                         "description": "Disorders of aromatic amino-acid metabolism"
                                     }
                                 ]
@@ -13056,7 +12753,6 @@
                                     {
                                         "key": "E71",
                                         "name": "E71",
-                                        "visible": false,
                                         "description": "Disorders of branched-chain amino-acid metabolism and fatty-acid metabolism"
                                     }
                                 ]
@@ -13109,7 +12805,6 @@
                                     {
                                         "key": "E72",
                                         "name": "E72",
-                                        "visible": false,
                                         "description": "Other disorders of amino-acid metabolism"
                                     }
                                 ]
@@ -13142,7 +12837,6 @@
                                     {
                                         "key": "E73",
                                         "name": "E73",
-                                        "visible": false,
                                         "description": "Lactose intolerance"
                                     }
                                 ]
@@ -13190,7 +12884,6 @@
                                     {
                                         "key": "E74",
                                         "name": "E74",
-                                        "visible": false,
                                         "description": "Other disorders of carbohydrate metabolism"
                                     }
                                 ]
@@ -13238,7 +12931,6 @@
                                     {
                                         "key": "E75",
                                         "name": "E75",
-                                        "visible": false,
                                         "description": "Disorders of sphingolipid metabolism and other lipid storage disorders"
                                     }
                                 ]
@@ -13281,7 +12973,6 @@
                                     {
                                         "key": "E76",
                                         "name": "E76",
-                                        "visible": false,
                                         "description": "Disorders of glycosaminoglycan metabolism"
                                     }
                                 ]
@@ -13314,7 +13005,6 @@
                                     {
                                         "key": "E77",
                                         "name": "E77",
-                                        "visible": false,
                                         "description": "Disorders of glycoprotein metabolism"
                                     }
                                 ]
@@ -13372,7 +13062,6 @@
                                     {
                                         "key": "E78",
                                         "name": "E78",
-                                        "visible": false,
                                         "description": "Disorders of lipoprotein metabolism and other lipidaemias"
                                     }
                                 ]
@@ -13405,7 +13094,6 @@
                                     {
                                         "key": "E79",
                                         "name": "E79",
-                                        "visible": false,
                                         "description": "Disorders of purine and pyrimidine metabolism"
                                     }
                                 ]
@@ -13458,7 +13146,6 @@
                                     {
                                         "key": "E80",
                                         "name": "E80",
-                                        "visible": false,
                                         "description": "Disorders of porphyrin and bilirubin metabolism"
                                     }
                                 ]
@@ -13511,7 +13198,6 @@
                                     {
                                         "key": "E83",
                                         "name": "E83",
-                                        "visible": false,
                                         "description": "Disorders of mineral metabolism"
                                     }
                                 ]
@@ -13544,7 +13230,6 @@
                                     {
                                         "key": "E84",
                                         "name": "E84",
-                                        "visible": false,
                                         "description": "Cystic fibrosis"
                                     }
                                 ]
@@ -13592,7 +13277,6 @@
                                     {
                                         "key": "E85",
                                         "name": "E85",
-                                        "visible": false,
                                         "description": "Amyloidosis"
                                     }
                                 ]
@@ -13655,7 +13339,6 @@
                                     {
                                         "key": "E87",
                                         "name": "E87",
-                                        "visible": false,
                                         "description": "Other disorders of fluid, electrolyte and acid-base balance"
                                     }
                                 ]
@@ -13698,7 +13381,6 @@
                                     {
                                         "key": "E88",
                                         "name": "E88",
-                                        "visible": false,
                                         "description": "Other metabolic disorders"
                                     }
                                 ]
@@ -13756,7 +13438,6 @@
                                     {
                                         "key": "E89",
                                         "name": "E89",
-                                        "visible": false,
                                         "description": "Postprocedural endocrine and metabolic disorders, not elsewhere classified"
                                     }
                                 ]
@@ -13806,7 +13487,6 @@
                                     {
                                         "key": "F01",
                                         "name": "F01",
-                                        "visible": false,
                                         "description": "Vascular dementia"
                                     }
                                 ]
@@ -13849,7 +13529,6 @@
                                     {
                                         "key": "F05",
                                         "name": "F05",
-                                        "visible": false,
                                         "description": "Delirium, not induced by alcohol and other psychoactive substances"
                                     }
                                 ]
@@ -13912,7 +13591,6 @@
                                     {
                                         "key": "F06",
                                         "name": "F06",
-                                        "visible": false,
                                         "description": "Other mental disorders due to brain damage and dysfunction and to physical disease"
                                     }
                                 ]
@@ -13950,7 +13628,6 @@
                                     {
                                         "key": "F07",
                                         "name": "F07",
-                                        "visible": false,
                                         "description": "Personality and behavioural disorders due to brain disease, damage and dysfunction"
                                     }
                                 ]
@@ -14063,7 +13740,6 @@
                                     {
                                         "key": "F20",
                                         "name": "F20",
-                                        "visible": false,
                                         "description": "Schizophrenia"
                                     }
                                 ]
@@ -14096,7 +13772,6 @@
                                     {
                                         "key": "F22",
                                         "name": "F22",
-                                        "visible": false,
                                         "description": "Persistent delusional disorders"
                                     }
                                 ]
@@ -14139,7 +13814,6 @@
                                     {
                                         "key": "F23",
                                         "name": "F23",
-                                        "visible": false,
                                         "description": "Acute and transient psychotic disorders"
                                     }
                                 ]
@@ -14182,7 +13856,6 @@
                                     {
                                         "key": "F25",
                                         "name": "F25",
-                                        "visible": false,
                                         "description": "Schizoaffective disorders"
                                     }
                                 ]
@@ -14230,7 +13903,6 @@
                                     {
                                         "key": "F30",
                                         "name": "F30",
-                                        "visible": false,
                                         "description": "Manic episode"
                                     }
                                 ]
@@ -14293,7 +13965,6 @@
                                     {
                                         "key": "F31",
                                         "name": "F31",
-                                        "visible": false,
                                         "description": "Bipolar affective disorder"
                                     }
                                 ]
@@ -14336,7 +14007,6 @@
                                     {
                                         "key": "F32",
                                         "name": "F32",
-                                        "visible": false,
                                         "description": "Depressive episode"
                                     }
                                 ]
@@ -14384,7 +14054,6 @@
                                     {
                                         "key": "F33",
                                         "name": "F33",
-                                        "visible": false,
                                         "description": "Recurrent depressive disorder"
                                     }
                                 ]
@@ -14417,7 +14086,6 @@
                                     {
                                         "key": "F34",
                                         "name": "F34",
-                                        "visible": false,
                                         "description": "Persistent mood [affective] disorders"
                                     }
                                 ]
@@ -14445,7 +14113,6 @@
                                     {
                                         "key": "F38",
                                         "name": "F38",
-                                        "visible": false,
                                         "description": "Other mood [affective] disorders"
                                     }
                                 ]
@@ -14488,7 +14155,6 @@
                                     {
                                         "key": "F40",
                                         "name": "F40",
-                                        "visible": false,
                                         "description": "Phobic anxiety disorders"
                                     }
                                 ]
@@ -14531,7 +14197,6 @@
                                     {
                                         "key": "F41",
                                         "name": "F41",
-                                        "visible": false,
                                         "description": "Other anxiety disorders"
                                     }
                                 ]
@@ -14569,7 +14234,6 @@
                                     {
                                         "key": "F42",
                                         "name": "F42",
-                                        "visible": false,
                                         "description": "Obsessive-compulsive disorder"
                                     }
                                 ]
@@ -14607,7 +14271,6 @@
                                     {
                                         "key": "F43",
                                         "name": "F43",
-                                        "visible": false,
                                         "description": "Reaction to severe stress, and adjustment disorders"
                                     }
                                 ]
@@ -14670,7 +14333,6 @@
                                     {
                                         "key": "F44",
                                         "name": "F44",
-                                        "visible": false,
                                         "description": "Dissociative [conversion] disorders"
                                     }
                                 ]
@@ -14718,7 +14380,6 @@
                                     {
                                         "key": "F45",
                                         "name": "F45",
-                                        "visible": false,
                                         "description": "Somatoform disorders"
                                     }
                                 ]
@@ -14751,7 +14412,6 @@
                                     {
                                         "key": "F48",
                                         "name": "F48",
-                                        "visible": false,
                                         "description": "Other neurotic disorders"
                                     }
                                 ]
@@ -14804,7 +14464,6 @@
                                     {
                                         "key": "F50",
                                         "name": "F50",
-                                        "visible": false,
                                         "description": "Eating disorders"
                                     }
                                 ]
@@ -14857,7 +14516,6 @@
                                     {
                                         "key": "F51",
                                         "name": "F51",
-                                        "visible": false,
                                         "description": "Nonorganic sleep disorders"
                                     }
                                 ]
@@ -14920,7 +14578,6 @@
                                     {
                                         "key": "F52",
                                         "name": "F52",
-                                        "visible": false,
                                         "description": "Sexual dysfunction, not caused by organic disorder or disease"
                                     }
                                 ]
@@ -14953,7 +14610,6 @@
                                     {
                                         "key": "F53",
                                         "name": "F53",
-                                        "visible": false,
                                         "description": "Mental and behavioural disorders associated with the puerperium, not elsewhere classified"
                                     }
                                 ]
@@ -15031,7 +14687,6 @@
                                     {
                                         "key": "F60",
                                         "name": "F60",
-                                        "visible": false,
                                         "description": "Specific personality disorders"
                                     }
                                 ]
@@ -15069,7 +14724,6 @@
                                     {
                                         "key": "F62",
                                         "name": "F62",
-                                        "visible": false,
                                         "description": "Enduring personality changes, not attributable to brain damage and disease"
                                     }
                                 ]
@@ -15112,7 +14766,6 @@
                                     {
                                         "key": "F63",
                                         "name": "F63",
-                                        "visible": false,
                                         "description": "Habit and impulse disorders"
                                     }
                                 ]
@@ -15150,7 +14803,6 @@
                                     {
                                         "key": "F64",
                                         "name": "F64",
-                                        "visible": false,
                                         "description": "Gender identity disorders"
                                     }
                                 ]
@@ -15208,7 +14860,6 @@
                                     {
                                         "key": "F65",
                                         "name": "F65",
-                                        "visible": false,
                                         "description": "Disorders of sexual preference"
                                     }
                                 ]
@@ -15246,7 +14897,6 @@
                                     {
                                         "key": "F66",
                                         "name": "F66",
-                                        "visible": false,
                                         "description": "Psychological and behavioural disorders associated with sexual development and orientation"
                                     }
                                 ]
@@ -15274,7 +14924,6 @@
                                     {
                                         "key": "F68",
                                         "name": "F68",
-                                        "visible": false,
                                         "description": "Other disorders of adult personality and behaviour"
                                     }
                                 ]
@@ -15352,7 +15001,6 @@
                                     {
                                         "key": "F80",
                                         "name": "F80",
-                                        "visible": false,
                                         "description": "Specific developmental disorders of speech and language"
                                     }
                                 ]
@@ -15395,7 +15043,6 @@
                                     {
                                         "key": "F81",
                                         "name": "F81",
-                                        "visible": false,
                                         "description": "Specific developmental disorders of scholastic skills"
                                     }
                                 ]
@@ -15458,7 +15105,6 @@
                                     {
                                         "key": "F84",
                                         "name": "F84",
-                                        "visible": false,
                                         "description": "Pervasive developmental disorders"
                                     }
                                 ]
@@ -15501,7 +15147,6 @@
                                     {
                                         "key": "F90",
                                         "name": "F90",
-                                        "visible": false,
                                         "description": "Hyperkinetic disorders"
                                     }
                                 ]
@@ -15544,7 +15189,6 @@
                                     {
                                         "key": "F91",
                                         "name": "F91",
-                                        "visible": false,
                                         "description": "Conduct disorders"
                                     }
                                 ]
@@ -15572,7 +15216,6 @@
                                     {
                                         "key": "F92",
                                         "name": "F92",
-                                        "visible": false,
                                         "description": "Mixed disorders of conduct and emotions"
                                     }
                                 ]
@@ -15615,7 +15258,6 @@
                                     {
                                         "key": "F93",
                                         "name": "F93",
-                                        "visible": false,
                                         "description": "Emotional disorders with onset specific to childhood"
                                     }
                                 ]
@@ -15653,7 +15295,6 @@
                                     {
                                         "key": "F94",
                                         "name": "F94",
-                                        "visible": false,
                                         "description": "Disorders of social functioning with onset specific to childhood and adolescence"
                                     }
                                 ]
@@ -15691,7 +15332,6 @@
                                     {
                                         "key": "F95",
                                         "name": "F95",
-                                        "visible": false,
                                         "description": "Tic disorders"
                                     }
                                 ]
@@ -15749,7 +15389,6 @@
                                     {
                                         "key": "F98",
                                         "name": "F98",
-                                        "visible": false,
                                         "description": "Other behavioural and emotional disorders with onset usually occurring in childhood and adolescence"
                                     }
                                 ]
@@ -15804,7 +15443,6 @@
                                     {
                                         "key": "G00",
                                         "name": "G00",
-                                        "visible": false,
                                         "description": "Bacterial meningitis, not elsewhere classified"
                                     }
                                 ]
@@ -15842,7 +15480,6 @@
                                     {
                                         "key": "G03",
                                         "name": "G03",
-                                        "visible": false,
                                         "description": "Meningitis due to other and unspecified causes"
                                     }
                                 ]
@@ -15880,7 +15517,6 @@
                                     {
                                         "key": "G04",
                                         "name": "G04",
-                                        "visible": false,
                                         "description": "Encephalitis, myelitis and encephalomyelitis"
                                     }
                                 ]
@@ -15908,7 +15544,6 @@
                                     {
                                         "key": "G06",
                                         "name": "G06",
-                                        "visible": false,
                                         "description": "Intracranial and intraspinal abscess and granuloma"
                                     }
                                 ]
@@ -15971,7 +15606,6 @@
                                     {
                                         "key": "G11",
                                         "name": "G11",
-                                        "visible": false,
                                         "description": "Hereditary ataxia"
                                     }
                                 ]
@@ -16009,7 +15643,6 @@
                                     {
                                         "key": "G12",
                                         "name": "G12",
-                                        "visible": false,
                                         "description": "Spinal muscular atrophy and related syndromes"
                                     }
                                 ]
@@ -16067,7 +15700,6 @@
                                     {
                                         "key": "G21",
                                         "name": "G21",
-                                        "visible": false,
                                         "description": "Secondary parkinsonism"
                                     }
                                 ]
@@ -16110,7 +15742,6 @@
                                     {
                                         "key": "G23",
                                         "name": "G23",
-                                        "visible": false,
                                         "description": "Other degenerative diseases of basal ganglia"
                                     }
                                 ]
@@ -16163,7 +15794,6 @@
                                     {
                                         "key": "G24",
                                         "name": "G24",
-                                        "visible": false,
                                         "description": "Dystonia"
                                     }
                                 ]
@@ -16221,7 +15851,6 @@
                                     {
                                         "key": "G25",
                                         "name": "G25",
-                                        "visible": false,
                                         "description": "Other extrapyramidal and movement disorders"
                                     }
                                 ]
@@ -16259,7 +15888,6 @@
                                     {
                                         "key": "G31",
                                         "name": "G31",
-                                        "visible": false,
                                         "description": "Other degenerative diseases of nervous system, not elsewhere classified"
                                     }
                                 ]
@@ -16297,7 +15925,6 @@
                                     {
                                         "key": "G36",
                                         "name": "G36",
-                                        "visible": false,
                                         "description": "Other acute disseminated demyelination"
                                     }
                                 ]
@@ -16350,7 +15977,6 @@
                                     {
                                         "key": "G37",
                                         "name": "G37",
-                                        "visible": false,
                                         "description": "Other demyelinating diseases of central nervous system"
                                     }
                                 ]
@@ -16413,7 +16039,6 @@
                                     {
                                         "key": "G40",
                                         "name": "G40",
-                                        "visible": false,
                                         "description": "Epilepsy"
                                     }
                                 ]
@@ -16451,7 +16076,6 @@
                                     {
                                         "key": "G41",
                                         "name": "G41",
-                                        "visible": false,
                                         "description": "Status epilepticus"
                                     }
                                 ]
@@ -16494,7 +16118,6 @@
                                     {
                                         "key": "G43",
                                         "name": "G43",
-                                        "visible": false,
                                         "description": "Migraine"
                                     }
                                 ]
@@ -16537,7 +16160,6 @@
                                     {
                                         "key": "G44",
                                         "name": "G44",
-                                        "visible": false,
                                         "description": "Other headache syndromes"
                                     }
                                 ]
@@ -16585,7 +16207,6 @@
                                     {
                                         "key": "G45",
                                         "name": "G45",
-                                        "visible": false,
                                         "description": "Transient cerebral ischaemic attacks and related syndromes"
                                     }
                                 ]
@@ -16633,7 +16254,6 @@
                                     {
                                         "key": "G47",
                                         "name": "G47",
-                                        "visible": false,
                                         "description": "Sleep disorders"
                                     }
                                 ]
@@ -16666,7 +16286,6 @@
                                     {
                                         "key": "G50",
                                         "name": "G50",
-                                        "visible": false,
                                         "description": "Disorders of trigeminal nerve"
                                     }
                                 ]
@@ -16714,7 +16333,6 @@
                                     {
                                         "key": "G51",
                                         "name": "G51",
-                                        "visible": false,
                                         "description": "Facial nerve disorders"
                                     }
                                 ]
@@ -16762,7 +16380,6 @@
                                     {
                                         "key": "G52",
                                         "name": "G52",
-                                        "visible": false,
                                         "description": "Disorders of other cranial nerves"
                                     }
                                 ]
@@ -16825,7 +16442,6 @@
                                     {
                                         "key": "G54",
                                         "name": "G54",
-                                        "visible": false,
                                         "description": "Nerve root and plexus disorders"
                                     }
                                 ]
@@ -16868,7 +16484,6 @@
                                     {
                                         "key": "G56",
                                         "name": "G56",
-                                        "visible": false,
                                         "description": "Mononeuropathies of upper limb"
                                     }
                                 ]
@@ -16926,7 +16541,6 @@
                                     {
                                         "key": "G57",
                                         "name": "G57",
-                                        "visible": false,
                                         "description": "Mononeuropathies of lower limb"
                                     }
                                 ]
@@ -16959,7 +16573,6 @@
                                     {
                                         "key": "G58",
                                         "name": "G58",
-                                        "visible": false,
                                         "description": "Other mononeuropathies"
                                     }
                                 ]
@@ -17002,7 +16615,6 @@
                                     {
                                         "key": "G60",
                                         "name": "G60",
-                                        "visible": false,
                                         "description": "Hereditary and idiopathic neuropathy"
                                     }
                                 ]
@@ -17035,7 +16647,6 @@
                                     {
                                         "key": "G61",
                                         "name": "G61",
-                                        "visible": false,
                                         "description": "Inflammatory polyneuropathy"
                                     }
                                 ]
@@ -17073,7 +16684,6 @@
                                     {
                                         "key": "G62",
                                         "name": "G62",
-                                        "visible": false,
                                         "description": "Other polyneuropathies"
                                     }
                                 ]
@@ -17116,7 +16726,6 @@
                                     {
                                         "key": "G70",
                                         "name": "G70",
-                                        "visible": false,
                                         "description": "Myasthenia gravis and other myoneural disorders"
                                     }
                                 ]
@@ -17159,7 +16768,6 @@
                                     {
                                         "key": "G71",
                                         "name": "G71",
-                                        "visible": false,
                                         "description": "Primary disorders of muscles"
                                     }
                                 ]
@@ -17207,7 +16815,6 @@
                                     {
                                         "key": "G72",
                                         "name": "G72",
-                                        "visible": false,
                                         "description": "Other myopathies"
                                     }
                                 ]
@@ -17255,7 +16862,6 @@
                                     {
                                         "key": "G80",
                                         "name": "G80",
-                                        "visible": false,
                                         "description": "Cerebral palsy"
                                     }
                                 ]
@@ -17283,7 +16889,6 @@
                                     {
                                         "key": "G81",
                                         "name": "G81",
-                                        "visible": false,
                                         "description": "Hemiplegia"
                                     }
                                 ]
@@ -17326,7 +16931,6 @@
                                     {
                                         "key": "G82",
                                         "name": "G82",
-                                        "visible": false,
                                         "description": "Paraplegia and tetraplegia"
                                     }
                                 ]
@@ -17384,7 +16988,6 @@
                                     {
                                         "key": "G83",
                                         "name": "G83",
-                                        "visible": false,
                                         "description": "Other paralytic syndromes"
                                     }
                                 ]
@@ -17442,7 +17045,6 @@
                                     {
                                         "key": "G90",
                                         "name": "G90",
-                                        "visible": false,
                                         "description": "Disorders of autonomic nervous system"
                                     }
                                 ]
@@ -17485,7 +17087,6 @@
                                     {
                                         "key": "G91",
                                         "name": "G91",
-                                        "visible": false,
                                         "description": "Hydrocephalus"
                                     }
                                 ]
@@ -17553,7 +17154,6 @@
                                     {
                                         "key": "G93",
                                         "name": "G93",
-                                        "visible": false,
                                         "description": "Other disorders of brain"
                                     }
                                 ]
@@ -17591,7 +17191,6 @@
                                     {
                                         "key": "G95",
                                         "name": "G95",
-                                        "visible": false,
                                         "description": "Other diseases of spinal cord"
                                     }
                                 ]
@@ -17624,7 +17223,6 @@
                                     {
                                         "key": "G96",
                                         "name": "G96",
-                                        "visible": false,
                                         "description": "Other disorders of central nervous system"
                                     }
                                 ]
@@ -17662,7 +17260,6 @@
                                     {
                                         "key": "G97",
                                         "name": "G97",
-                                        "visible": false,
                                         "description": "Postprocedural disorders of nervous system, not elsewhere classified"
                                     }
                                 ]
@@ -17697,7 +17294,6 @@
                                     {
                                         "key": "H00",
                                         "name": "H00",
-                                        "visible": false,
                                         "description": "Hordeolum and chalazion"
                                     }
                                 ]
@@ -17730,7 +17326,6 @@
                                     {
                                         "key": "H01",
                                         "name": "H01",
-                                        "visible": false,
                                         "description": "Other inflammation of eyelid"
                                     }
                                 ]
@@ -17793,7 +17388,6 @@
                                     {
                                         "key": "H02",
                                         "name": "H02",
-                                        "visible": false,
                                         "description": "Other disorders of eyelid"
                                     }
                                 ]
@@ -17851,7 +17445,6 @@
                                     {
                                         "key": "H04",
                                         "name": "H04",
-                                        "visible": false,
                                         "description": "Disorders of lacrimal system"
                                     }
                                 ]
@@ -17904,7 +17497,6 @@
                                     {
                                         "key": "H05",
                                         "name": "H05",
-                                        "visible": false,
                                         "description": "Disorders of orbit"
                                     }
                                 ]
@@ -17957,7 +17549,6 @@
                                     {
                                         "key": "H10",
                                         "name": "H10",
-                                        "visible": false,
                                         "description": "Conjunctivitis"
                                     }
                                 ]
@@ -18005,7 +17596,6 @@
                                     {
                                         "key": "H11",
                                         "name": "H11",
-                                        "visible": false,
                                         "description": "Other disorders of conjunctiva"
                                     }
                                 ]
@@ -18038,7 +17628,6 @@
                                     {
                                         "key": "H15",
                                         "name": "H15",
-                                        "visible": false,
                                         "description": "Disorders of sclera"
                                     }
                                 ]
@@ -18086,7 +17675,6 @@
                                     {
                                         "key": "H16",
                                         "name": "H16",
-                                        "visible": false,
                                         "description": "Keratitis"
                                     }
                                 ]
@@ -18119,7 +17707,6 @@
                                     {
                                         "key": "H17",
                                         "name": "H17",
-                                        "visible": false,
                                         "description": "Corneal scars and opacities"
                                     }
                                 ]
@@ -18182,7 +17769,6 @@
                                     {
                                         "key": "H18",
                                         "name": "H18",
-                                        "visible": false,
                                         "description": "Other disorders of cornea"
                                     }
                                 ]
@@ -18220,7 +17806,6 @@
                                     {
                                         "key": "H20",
                                         "name": "H20",
-                                        "visible": false,
                                         "description": "Iridocyclitis"
                                     }
                                 ]
@@ -18273,7 +17858,6 @@
                                     {
                                         "key": "H21",
                                         "name": "H21",
-                                        "visible": false,
                                         "description": "Other disorders of iris and ciliary body"
                                     }
                                 ]
@@ -18311,7 +17895,6 @@
                                     {
                                         "key": "H25",
                                         "name": "H25",
-                                        "visible": false,
                                         "description": "Senile cataract"
                                     }
                                 ]
@@ -18359,7 +17942,6 @@
                                     {
                                         "key": "H26",
                                         "name": "H26",
-                                        "visible": false,
                                         "description": "Other cataract"
                                     }
                                 ]
@@ -18392,7 +17974,6 @@
                                     {
                                         "key": "H27",
                                         "name": "H27",
-                                        "visible": false,
                                         "description": "Other disorders of lens"
                                     }
                                 ]
@@ -18430,7 +18011,6 @@
                                     {
                                         "key": "H30",
                                         "name": "H30",
-                                        "visible": false,
                                         "description": "Chorioretinal inflammation"
                                     }
                                 ]
@@ -18478,7 +18058,6 @@
                                     {
                                         "key": "H31",
                                         "name": "H31",
-                                        "visible": false,
                                         "description": "Other disorders of choroid"
                                     }
                                 ]
@@ -18521,7 +18100,6 @@
                                     {
                                         "key": "H33",
                                         "name": "H33",
-                                        "visible": false,
                                         "description": "Retinal detachments and breaks"
                                     }
                                 ]
@@ -18559,7 +18137,6 @@
                                     {
                                         "key": "H34",
                                         "name": "H34",
-                                        "visible": false,
                                         "description": "Retinal vascular occlusions"
                                     }
                                 ]
@@ -18622,7 +18199,6 @@
                                     {
                                         "key": "H35",
                                         "name": "H35",
-                                        "visible": false,
                                         "description": "Other retinal disorders"
                                     }
                                 ]
@@ -18680,7 +18256,6 @@
                                     {
                                         "key": "H40",
                                         "name": "H40",
-                                        "visible": false,
                                         "description": "Glaucoma"
                                     }
                                 ]
@@ -18723,7 +18298,6 @@
                                     {
                                         "key": "H43",
                                         "name": "H43",
-                                        "visible": false,
                                         "description": "Disorders of vitreous body"
                                     }
                                 ]
@@ -18786,7 +18360,6 @@
                                     {
                                         "key": "H44",
                                         "name": "H44",
-                                        "visible": false,
                                         "description": "Disorders of globe"
                                     }
                                 ]
@@ -18844,7 +18417,6 @@
                                     {
                                         "key": "H47",
                                         "name": "H47",
-                                        "visible": false,
                                         "description": "Other disorders of optic [2nd] nerve and visual pathways"
                                     }
                                 ]
@@ -18892,7 +18464,6 @@
                                     {
                                         "key": "H49",
                                         "name": "H49",
-                                        "visible": false,
                                         "description": "Paralytic strabismus"
                                     }
                                 ]
@@ -18950,7 +18521,6 @@
                                     {
                                         "key": "H50",
                                         "name": "H50",
-                                        "visible": false,
                                         "description": "Other strabismus"
                                     }
                                 ]
@@ -18988,7 +18558,6 @@
                                     {
                                         "key": "H51",
                                         "name": "H51",
-                                        "visible": false,
                                         "description": "Other disorders of binocular movement"
                                     }
                                 ]
@@ -19041,7 +18610,6 @@
                                     {
                                         "key": "H52",
                                         "name": "H52",
-                                        "visible": false,
                                         "description": "Disorders of refraction and accommodation"
                                     }
                                 ]
@@ -19099,7 +18667,6 @@
                                     {
                                         "key": "H53",
                                         "name": "H53",
-                                        "visible": false,
                                         "description": "Visual disturbances"
                                     }
                                 ]
@@ -19152,7 +18719,6 @@
                                     {
                                         "key": "H54",
                                         "name": "H54",
-                                        "visible": false,
                                         "description": "Visual impairment including blindness (binocular or monocular)"
                                     }
                                 ]
@@ -19190,7 +18756,6 @@
                                     {
                                         "key": "H57",
                                         "name": "H57",
-                                        "visible": false,
                                         "description": "Other disorders of eye and adnexa"
                                     }
                                 ]
@@ -19218,7 +18783,6 @@
                                     {
                                         "key": "H59",
                                         "name": "H59",
-                                        "visible": false,
                                         "description": "Postprocedural disorders of eye and adnexa, not elsewhere classified"
                                     }
                                 ]
@@ -19271,7 +18835,6 @@
                                     {
                                         "key": "H60",
                                         "name": "H60",
-                                        "visible": false,
                                         "description": "Otitis externa"
                                     }
                                 ]
@@ -19314,7 +18877,6 @@
                                     {
                                         "key": "H61",
                                         "name": "H61",
-                                        "visible": false,
                                         "description": "Other disorders of external ear"
                                     }
                                 ]
@@ -19357,7 +18919,6 @@
                                     {
                                         "key": "H65",
                                         "name": "H65",
-                                        "visible": false,
                                         "description": "Nonsuppurative otitis media"
                                     }
                                 ]
@@ -19400,7 +18961,6 @@
                                     {
                                         "key": "H66",
                                         "name": "H66",
-                                        "visible": false,
                                         "description": "Suppurative and unspecified otitis media"
                                     }
                                 ]
@@ -19423,7 +18983,6 @@
                                     {
                                         "key": "H68",
                                         "name": "H68",
-                                        "visible": false,
                                         "description": "Eustachian salpingitis and obstruction"
                                     }
                                 ]
@@ -19451,7 +19010,6 @@
                                     {
                                         "key": "H69",
                                         "name": "H69",
-                                        "visible": false,
                                         "description": "Other disorders of Eustachian tube"
                                     }
                                 ]
@@ -19489,7 +19047,6 @@
                                     {
                                         "key": "H70",
                                         "name": "H70",
-                                        "visible": false,
                                         "description": "Mastoiditis and related conditions"
                                     }
                                 ]
@@ -19532,7 +19089,6 @@
                                     {
                                         "key": "H72",
                                         "name": "H72",
-                                        "visible": false,
                                         "description": "Perforation of tympanic membrane"
                                     }
                                 ]
@@ -19565,7 +19121,6 @@
                                     {
                                         "key": "H73",
                                         "name": "H73",
-                                        "visible": false,
                                         "description": "Other disorders of tympanic membrane"
                                     }
                                 ]
@@ -19613,7 +19168,6 @@
                                     {
                                         "key": "H74",
                                         "name": "H74",
-                                        "visible": false,
                                         "description": "Other disorders of middle ear and mastoid"
                                     }
                                 ]
@@ -19651,7 +19205,6 @@
                                     {
                                         "key": "H80",
                                         "name": "H80",
-                                        "visible": false,
                                         "description": "Otosclerosis"
                                     }
                                 ]
@@ -19699,7 +19252,6 @@
                                     {
                                         "key": "H81",
                                         "name": "H81",
-                                        "visible": false,
                                         "description": "Disorders of vestibular function"
                                     }
                                 ]
@@ -19742,7 +19294,6 @@
                                     {
                                         "key": "H83",
                                         "name": "H83",
-                                        "visible": false,
                                         "description": "Other diseases of inner ear"
                                     }
                                 ]
@@ -19800,7 +19351,6 @@
                                     {
                                         "key": "H90",
                                         "name": "H90",
-                                        "visible": false,
                                         "description": "Conductive and sensorineural hearing loss"
                                     }
                                 ]
@@ -19843,7 +19393,6 @@
                                     {
                                         "key": "H91",
                                         "name": "H91",
-                                        "visible": false,
                                         "description": "Other hearing loss"
                                     }
                                 ]
@@ -19871,7 +19420,6 @@
                                     {
                                         "key": "H92",
                                         "name": "H92",
-                                        "visible": false,
                                         "description": "Otalgia and effusion of ear"
                                     }
                                 ]
@@ -19914,7 +19462,6 @@
                                     {
                                         "key": "H93",
                                         "name": "H93",
-                                        "visible": false,
                                         "description": "Other disorders of ear, not elsewhere classified"
                                     }
                                 ]
@@ -19947,7 +19494,6 @@
                                     {
                                         "key": "H95",
                                         "name": "H95",
-                                        "visible": false,
                                         "description": "Postprocedural disorders of ear and mastoid process, not elsewhere classified"
                                     }
                                 ]
@@ -19997,7 +19543,6 @@
                                     {
                                         "key": "I01",
                                         "name": "I01",
-                                        "visible": false,
                                         "description": "Rheumatic fever with heart involvement"
                                     }
                                 ]
@@ -20020,7 +19565,6 @@
                                     {
                                         "key": "I02",
                                         "name": "I02",
-                                        "visible": false,
                                         "description": "Rheumatic chorea"
                                     }
                                 ]
@@ -20058,7 +19602,6 @@
                                     {
                                         "key": "I05",
                                         "name": "I05",
-                                        "visible": false,
                                         "description": "Rheumatic mitral valve diseases"
                                     }
                                 ]
@@ -20096,7 +19639,6 @@
                                     {
                                         "key": "I06",
                                         "name": "I06",
-                                        "visible": false,
                                         "description": "Rheumatic aortic valve diseases"
                                     }
                                 ]
@@ -20134,7 +19676,6 @@
                                     {
                                         "key": "I07",
                                         "name": "I07",
-                                        "visible": false,
                                         "description": "Rheumatic tricuspid valve diseases"
                                     }
                                 ]
@@ -20177,7 +19718,6 @@
                                     {
                                         "key": "I08",
                                         "name": "I08",
-                                        "visible": false,
                                         "description": "Multiple valve diseases"
                                     }
                                 ]
@@ -20215,7 +19755,6 @@
                                     {
                                         "key": "I09",
                                         "name": "I09",
-                                        "visible": false,
                                         "description": "Other rheumatic heart diseases"
                                     }
                                 ]
@@ -20243,7 +19782,6 @@
                                     {
                                         "key": "I11",
                                         "name": "I11",
-                                        "visible": false,
                                         "description": "Hypertensive heart disease"
                                     }
                                 ]
@@ -20266,7 +19804,6 @@
                                     {
                                         "key": "I12",
                                         "name": "I12",
-                                        "visible": false,
                                         "description": "Hypertensive renal disease"
                                     }
                                 ]
@@ -20299,7 +19836,6 @@
                                     {
                                         "key": "I13",
                                         "name": "I13",
-                                        "visible": false,
                                         "description": "Hypertensive heart and renal disease"
                                     }
                                 ]
@@ -20337,7 +19873,6 @@
                                     {
                                         "key": "I15",
                                         "name": "I15",
-                                        "visible": false,
                                         "description": "Secondary hypertension"
                                     }
                                 ]
@@ -20370,7 +19905,6 @@
                                     {
                                         "key": "I20",
                                         "name": "I20",
-                                        "visible": false,
                                         "description": "Angina pectoris"
                                     }
                                 ]
@@ -20413,7 +19947,6 @@
                                     {
                                         "key": "I21",
                                         "name": "I21",
-                                        "visible": false,
                                         "description": "Acute myocardial infarction"
                                     }
                                 ]
@@ -20446,7 +19979,6 @@
                                     {
                                         "key": "I22",
                                         "name": "I22",
-                                        "visible": false,
                                         "description": "Subsequent myocardial infarction"
                                     }
                                 ]
@@ -20499,7 +20031,6 @@
                                     {
                                         "key": "I23",
                                         "name": "I23",
-                                        "visible": false,
                                         "description": "Certain current complications following acute myocardial infarction"
                                     }
                                 ]
@@ -20532,7 +20063,6 @@
                                     {
                                         "key": "I24",
                                         "name": "I24",
-                                        "visible": false,
                                         "description": "Other acute ischaemic heart diseases"
                                     }
                                 ]
@@ -20590,7 +20120,6 @@
                                     {
                                         "key": "I25",
                                         "name": "I25",
-                                        "visible": false,
                                         "description": "Chronic ischaemic heart disease"
                                     }
                                 ]
@@ -20613,7 +20142,6 @@
                                     {
                                         "key": "I26",
                                         "name": "I26",
-                                        "visible": false,
                                         "description": "Pulmonary embolism"
                                     }
                                 ]
@@ -20651,7 +20179,6 @@
                                     {
                                         "key": "I27",
                                         "name": "I27",
-                                        "visible": false,
                                         "description": "Other pulmonary heart diseases"
                                     }
                                 ]
@@ -20684,7 +20211,6 @@
                                     {
                                         "key": "I28",
                                         "name": "I28",
-                                        "visible": false,
                                         "description": "Other diseases of pulmonary vessels"
                                     }
                                 ]
@@ -20717,7 +20243,6 @@
                                     {
                                         "key": "I30",
                                         "name": "I30",
-                                        "visible": false,
                                         "description": "Acute pericarditis"
                                     }
                                 ]
@@ -20760,7 +20285,6 @@
                                     {
                                         "key": "I31",
                                         "name": "I31",
-                                        "visible": false,
                                         "description": "Other diseases of pericardium"
                                     }
                                 ]
@@ -20783,7 +20307,6 @@
                                     {
                                         "key": "I33",
                                         "name": "I33",
-                                        "visible": false,
                                         "description": "Acute and subacute endocarditis"
                                     }
                                 ]
@@ -20821,7 +20344,6 @@
                                     {
                                         "key": "I34",
                                         "name": "I34",
-                                        "visible": false,
                                         "description": "Nonrheumatic mitral valve disorders"
                                     }
                                 ]
@@ -20859,7 +20381,6 @@
                                     {
                                         "key": "I35",
                                         "name": "I35",
-                                        "visible": false,
                                         "description": "Nonrheumatic aortic valve disorders"
                                     }
                                 ]
@@ -20897,7 +20418,6 @@
                                     {
                                         "key": "I36",
                                         "name": "I36",
-                                        "visible": false,
                                         "description": "Nonrheumatic tricuspid valve disorders"
                                     }
                                 ]
@@ -20935,7 +20455,6 @@
                                     {
                                         "key": "I37",
                                         "name": "I37",
-                                        "visible": false,
                                         "description": "Pulmonary valve disorders"
                                     }
                                 ]
@@ -20973,7 +20492,6 @@
                                     {
                                         "key": "I40",
                                         "name": "I40",
-                                        "visible": false,
                                         "description": "Acute myocarditis"
                                     }
                                 ]
@@ -21036,7 +20554,6 @@
                                     {
                                         "key": "I42",
                                         "name": "I42",
-                                        "visible": false,
                                         "description": "Cardiomyopathy"
                                     }
                                 ]
@@ -21089,7 +20606,6 @@
                                     {
                                         "key": "I44",
                                         "name": "I44",
-                                        "visible": false,
                                         "description": "Atrioventricular and left bundle-branch block"
                                     }
                                 ]
@@ -21147,7 +20663,6 @@
                                     {
                                         "key": "I45",
                                         "name": "I45",
-                                        "visible": false,
                                         "description": "Other conduction disorders"
                                     }
                                 ]
@@ -21175,7 +20690,6 @@
                                     {
                                         "key": "I46",
                                         "name": "I46",
-                                        "visible": false,
                                         "description": "Cardiac arrest"
                                     }
                                 ]
@@ -21208,7 +20722,6 @@
                                     {
                                         "key": "I47",
                                         "name": "I47",
-                                        "visible": false,
                                         "description": "Paroxysmal tachycardia"
                                     }
                                 ]
@@ -21251,7 +20764,6 @@
                                     {
                                         "key": "I48",
                                         "name": "I48",
-                                        "visible": false,
                                         "description": "Atrial fibrillation and flutter"
                                     }
                                 ]
@@ -21304,7 +20816,6 @@
                                     {
                                         "key": "I49",
                                         "name": "I49",
-                                        "visible": false,
                                         "description": "Other cardiac arrhythmias"
                                     }
                                 ]
@@ -21332,7 +20843,6 @@
                                     {
                                         "key": "I50",
                                         "name": "I50",
-                                        "visible": false,
                                         "description": "Heart failure"
                                     }
                                 ]
@@ -21395,7 +20905,6 @@
                                     {
                                         "key": "I51",
                                         "name": "I51",
-                                        "visible": false,
                                         "description": "Complications and ill-defined descriptions of heart disease"
                                     }
                                 ]
@@ -21458,7 +20967,6 @@
                                     {
                                         "key": "I60",
                                         "name": "I60",
-                                        "visible": false,
                                         "description": "Subarachnoid haemorrhage"
                                     }
                                 ]
@@ -21516,7 +21024,6 @@
                                     {
                                         "key": "I61",
                                         "name": "I61",
-                                        "visible": false,
                                         "description": "Intracerebral haemorrhage"
                                     }
                                 ]
@@ -21544,7 +21051,6 @@
                                     {
                                         "key": "I62",
                                         "name": "I62",
-                                        "visible": false,
                                         "description": "Other nontraumatic intracranial haemorrhage"
                                     }
                                 ]
@@ -21602,7 +21108,6 @@
                                     {
                                         "key": "I63",
                                         "name": "I63",
-                                        "visible": false,
                                         "description": "Cerebral infarction"
                                     }
                                 ]
@@ -21650,7 +21155,6 @@
                                     {
                                         "key": "I65",
                                         "name": "I65",
-                                        "visible": false,
                                         "description": "Occlusion and stenosis of precerebral arteries, not resulting in cerebral infarction"
                                     }
                                 ]
@@ -21698,7 +21202,6 @@
                                     {
                                         "key": "I66",
                                         "name": "I66",
-                                        "visible": false,
                                         "description": "Occlusion and stenosis of cerebral arteries, not resulting in cerebral infarction"
                                     }
                                 ]
@@ -21761,7 +21264,6 @@
                                     {
                                         "key": "I67",
                                         "name": "I67",
-                                        "visible": false,
                                         "description": "Other cerebrovascular diseases"
                                     }
                                 ]
@@ -21804,7 +21306,6 @@
                                     {
                                         "key": "I69",
                                         "name": "I69",
-                                        "visible": false,
                                         "description": "Sequelae of cerebrovascular disease"
                                     }
                                 ]
@@ -21842,7 +21343,6 @@
                                     {
                                         "key": "I70",
                                         "name": "I70",
-                                        "visible": false,
                                         "description": "Atherosclerosis"
                                     }
                                 ]
@@ -21900,7 +21400,6 @@
                                     {
                                         "key": "I71",
                                         "name": "I71",
-                                        "visible": false,
                                         "description": "Aortic aneurysm and dissection"
                                     }
                                 ]
@@ -21958,7 +21457,6 @@
                                     {
                                         "key": "I72",
                                         "name": "I72",
-                                        "visible": false,
                                         "description": "Other aneurysm and dissection"
                                     }
                                 ]
@@ -21991,7 +21489,6 @@
                                     {
                                         "key": "I73",
                                         "name": "I73",
-                                        "visible": false,
                                         "description": "Other peripheral vascular diseases"
                                     }
                                 ]
@@ -22044,7 +21541,6 @@
                                     {
                                         "key": "I74",
                                         "name": "I74",
-                                        "visible": false,
                                         "description": "Arterial embolism and thrombosis"
                                     }
                                 ]
@@ -22102,7 +21598,6 @@
                                     {
                                         "key": "I77",
                                         "name": "I77",
-                                        "visible": false,
                                         "description": "Other disorders of arteries and arterioles"
                                     }
                                 ]
@@ -22135,7 +21630,6 @@
                                     {
                                         "key": "I78",
                                         "name": "I78",
-                                        "visible": false,
                                         "description": "Diseases of capillaries"
                                     }
                                 ]
@@ -22178,7 +21672,6 @@
                                     {
                                         "key": "I80",
                                         "name": "I80",
-                                        "visible": false,
                                         "description": "Phlebitis and thrombophlebitis"
                                     }
                                 ]
@@ -22226,7 +21719,6 @@
                                     {
                                         "key": "I82",
                                         "name": "I82",
-                                        "visible": false,
                                         "description": "Other venous embolism and thrombosis"
                                     }
                                 ]
@@ -22259,7 +21751,6 @@
                                     {
                                         "key": "I83",
                                         "name": "I83",
-                                        "visible": false,
                                         "description": "Varicose veins of lower extremities"
                                     }
                                 ]
@@ -22282,7 +21773,6 @@
                                     {
                                         "key": "I85",
                                         "name": "I85",
-                                        "visible": false,
                                         "description": "Oesophageal varices"
                                     }
                                 ]
@@ -22325,7 +21815,6 @@
                                     {
                                         "key": "I86",
                                         "name": "I86",
-                                        "visible": false,
                                         "description": "Varicose veins of other sites"
                                     }
                                 ]
@@ -22363,7 +21852,6 @@
                                     {
                                         "key": "I87",
                                         "name": "I87",
-                                        "visible": false,
                                         "description": "Other disorders of veins"
                                     }
                                 ]
@@ -22396,7 +21884,6 @@
                                     {
                                         "key": "I88",
                                         "name": "I88",
-                                        "visible": false,
                                         "description": "Nonspecific lymphadenitis"
                                     }
                                 ]
@@ -22429,7 +21916,6 @@
                                     {
                                         "key": "I89",
                                         "name": "I89",
-                                        "visible": false,
                                         "description": "Other noninfective disorders of lymphatic vessels and lymph nodes"
                                     }
                                 ]
@@ -22467,7 +21953,6 @@
                                     {
                                         "key": "I95",
                                         "name": "I95",
-                                        "visible": false,
                                         "description": "Hypotension"
                                     }
                                 ]
@@ -22505,7 +21990,6 @@
                                     {
                                         "key": "I97",
                                         "name": "I97",
-                                        "visible": false,
                                         "description": "Postprocedural disorders of circulatory system, not elsewhere classified"
                                     }
                                 ]
@@ -22570,7 +22054,6 @@
                                     {
                                         "key": "J01",
                                         "name": "J01",
-                                        "visible": false,
                                         "description": "Acute sinusitis"
                                     }
                                 ]
@@ -22598,7 +22081,6 @@
                                     {
                                         "key": "J02",
                                         "name": "J02",
-                                        "visible": false,
                                         "description": "Acute pharyngitis"
                                     }
                                 ]
@@ -22626,7 +22108,6 @@
                                     {
                                         "key": "J03",
                                         "name": "J03",
-                                        "visible": false,
                                         "description": "Acute tonsillitis"
                                     }
                                 ]
@@ -22654,7 +22135,6 @@
                                     {
                                         "key": "J04",
                                         "name": "J04",
-                                        "visible": false,
                                         "description": "Acute laryngitis and tracheitis"
                                     }
                                 ]
@@ -22677,7 +22157,6 @@
                                     {
                                         "key": "J05",
                                         "name": "J05",
-                                        "visible": false,
                                         "description": "Acute obstructive laryngitis [croup] and epiglottitis"
                                     }
                                 ]
@@ -22705,7 +22184,6 @@
                                     {
                                         "key": "J06",
                                         "name": "J06",
-                                        "visible": false,
                                         "description": "Acute upper respiratory infections of multiple and unspecified sites"
                                     }
                                 ]
@@ -22738,7 +22216,6 @@
                                     {
                                         "key": "J10",
                                         "name": "J10",
-                                        "visible": false,
                                         "description": "Influenza due to identified seasonal influenza virus"
                                     }
                                 ]
@@ -22766,7 +22243,6 @@
                                     {
                                         "key": "J11",
                                         "name": "J11",
-                                        "visible": false,
                                         "description": "Influenza, virus not identified"
                                     }
                                 ]
@@ -22809,7 +22285,6 @@
                                     {
                                         "key": "J12",
                                         "name": "J12",
-                                        "visible": false,
                                         "description": "Viral pneumonia, not elsewhere classified"
                                     }
                                 ]
@@ -22882,7 +22357,6 @@
                                     {
                                         "key": "J15",
                                         "name": "J15",
-                                        "visible": false,
                                         "description": "Bacterial pneumonia, not elsewhere classified"
                                     }
                                 ]
@@ -22905,7 +22379,6 @@
                                     {
                                         "key": "J16",
                                         "name": "J16",
-                                        "visible": false,
                                         "description": "Pneumonia due to other infectious organisms, not elsewhere classified"
                                     }
                                 ]
@@ -22943,7 +22416,6 @@
                                     {
                                         "key": "J18",
                                         "name": "J18",
-                                        "visible": false,
                                         "description": "Pneumonia, organism unspecified"
                                     }
                                 ]
@@ -23006,7 +22478,6 @@
                                     {
                                         "key": "J20",
                                         "name": "J20",
-                                        "visible": false,
                                         "description": "Acute bronchitis"
                                     }
                                 ]
@@ -23039,7 +22510,6 @@
                                     {
                                         "key": "J21",
                                         "name": "J21",
-                                        "visible": false,
                                         "description": "Acute bronchiolitis"
                                     }
                                 ]
@@ -23082,7 +22552,6 @@
                                     {
                                         "key": "J30",
                                         "name": "J30",
-                                        "visible": false,
                                         "description": "Vasomotor and allergic rhinitis"
                                     }
                                 ]
@@ -23110,7 +22579,6 @@
                                     {
                                         "key": "J31",
                                         "name": "J31",
-                                        "visible": false,
                                         "description": "Chronic rhinitis, nasopharyngitis and pharyngitis"
                                     }
                                 ]
@@ -23158,7 +22626,6 @@
                                     {
                                         "key": "J32",
                                         "name": "J32",
-                                        "visible": false,
                                         "description": "Chronic sinusitis"
                                     }
                                 ]
@@ -23191,7 +22658,6 @@
                                     {
                                         "key": "J33",
                                         "name": "J33",
-                                        "visible": false,
                                         "description": "Nasal polyp"
                                     }
                                 ]
@@ -23229,7 +22695,6 @@
                                     {
                                         "key": "J34",
                                         "name": "J34",
-                                        "visible": false,
                                         "description": "Other disorders of nose and nasal sinuses"
                                     }
                                 ]
@@ -23272,7 +22737,6 @@
                                     {
                                         "key": "J35",
                                         "name": "J35",
-                                        "visible": false,
                                         "description": "Chronic diseases of tonsils and adenoids"
                                     }
                                 ]
@@ -23300,7 +22764,6 @@
                                     {
                                         "key": "J37",
                                         "name": "J37",
-                                        "visible": false,
                                         "description": "Chronic laryngitis and laryngotracheitis"
                                     }
                                 ]
@@ -23353,7 +22816,6 @@
                                     {
                                         "key": "J38",
                                         "name": "J38",
-                                        "visible": false,
                                         "description": "Diseases of vocal cords and larynx, not elsewhere classified"
                                     }
                                 ]
@@ -23396,7 +22858,6 @@
                                     {
                                         "key": "J39",
                                         "name": "J39",
-                                        "visible": false,
                                         "description": "Other diseases of upper respiratory tract"
                                     }
                                 ]
@@ -23429,7 +22890,6 @@
                                     {
                                         "key": "J41",
                                         "name": "J41",
-                                        "visible": false,
                                         "description": "Simple and mucopurulent chronic bronchitis"
                                     }
                                 ]
@@ -23472,7 +22932,6 @@
                                     {
                                         "key": "J43",
                                         "name": "J43",
-                                        "visible": false,
                                         "description": "Emphysema"
                                     }
                                 ]
@@ -23505,7 +22964,6 @@
                                     {
                                         "key": "J44",
                                         "name": "J44",
-                                        "visible": false,
                                         "description": "Other chronic obstructive pulmonary disease"
                                     }
                                 ]
@@ -23538,7 +22996,6 @@
                                     {
                                         "key": "J45",
                                         "name": "J45",
-                                        "visible": false,
                                         "description": "Asthma"
                                     }
                                 ]
@@ -23581,7 +23038,6 @@
                                     {
                                         "key": "J62",
                                         "name": "J62",
-                                        "visible": false,
                                         "description": "Pneumoconiosis due to dust containing silica"
                                     }
                                 ]
@@ -23629,7 +23085,6 @@
                                     {
                                         "key": "J63",
                                         "name": "J63",
-                                        "visible": false,
                                         "description": "Pneumoconiosis due to other inorganic dusts"
                                     }
                                 ]
@@ -23672,7 +23127,6 @@
                                     {
                                         "key": "J66",
                                         "name": "J66",
-                                        "visible": false,
                                         "description": "Airway disease due to specific organic dust"
                                     }
                                 ]
@@ -23735,7 +23189,6 @@
                                     {
                                         "key": "J67",
                                         "name": "J67",
-                                        "visible": false,
                                         "description": "Hypersensitivity pneumonitis due to organic dust"
                                     }
                                 ]
@@ -23783,7 +23236,6 @@
                                     {
                                         "key": "J68",
                                         "name": "J68",
-                                        "visible": false,
                                         "description": "Respiratory conditions due to inhalation of chemicals, gases, fumes and vapours"
                                     }
                                 ]
@@ -23811,7 +23263,6 @@
                                     {
                                         "key": "J69",
                                         "name": "J69",
-                                        "visible": false,
                                         "description": "Pneumonitis due to solids and liquids"
                                     }
                                 ]
@@ -23859,7 +23310,6 @@
                                     {
                                         "key": "J70",
                                         "name": "J70",
-                                        "visible": false,
                                         "description": "Respiratory conditions due to other external agents"
                                     }
                                 ]
@@ -23907,7 +23357,6 @@
                                     {
                                         "key": "J84",
                                         "name": "J84",
-                                        "visible": false,
                                         "description": "Other interstitial pulmonary diseases"
                                     }
                                 ]
@@ -23940,7 +23389,6 @@
                                     {
                                         "key": "J85",
                                         "name": "J85",
-                                        "visible": false,
                                         "description": "Abscess of lung and mediastinum"
                                     }
                                 ]
@@ -23963,7 +23411,6 @@
                                     {
                                         "key": "J86",
                                         "name": "J86",
-                                        "visible": false,
                                         "description": "Pyothorax"
                                     }
                                 ]
@@ -23991,7 +23438,6 @@
                                     {
                                         "key": "J92",
                                         "name": "J92",
-                                        "visible": false,
                                         "description": "Pleural plaque"
                                     }
                                 ]
@@ -24024,7 +23470,6 @@
                                     {
                                         "key": "J93",
                                         "name": "J93",
-                                        "visible": false,
                                         "description": "Pneumothorax"
                                     }
                                 ]
@@ -24062,7 +23507,6 @@
                                     {
                                         "key": "J94",
                                         "name": "J94",
-                                        "visible": false,
                                         "description": "Other pleural conditions"
                                     }
                                 ]
@@ -24115,7 +23559,6 @@
                                     {
                                         "key": "J95",
                                         "name": "J95",
-                                        "visible": false,
                                         "description": "Postprocedural respiratory disorders, not elsewhere classified"
                                     }
                                 ]
@@ -24143,7 +23586,6 @@
                                     {
                                         "key": "J96",
                                         "name": "J96",
-                                        "visible": false,
                                         "description": "Respiratory failure, not elsewhere classified"
                                     }
                                 ]
@@ -24206,7 +23648,6 @@
                                     {
                                         "key": "J98",
                                         "name": "J98",
-                                        "visible": false,
                                         "description": "Other respiratory disorders"
                                     }
                                 ]
@@ -24276,7 +23717,6 @@
                                     {
                                         "key": "K00",
                                         "name": "K00",
-                                        "visible": false,
                                         "description": "Disorders of tooth development and eruption"
                                     }
                                 ]
@@ -24299,7 +23739,6 @@
                                     {
                                         "key": "K01",
                                         "name": "K01",
-                                        "visible": false,
                                         "description": "Embedded and impacted teeth"
                                     }
                                 ]
@@ -24352,7 +23791,6 @@
                                     {
                                         "key": "K02",
                                         "name": "K02",
-                                        "visible": false,
                                         "description": "Dental caries"
                                     }
                                 ]
@@ -24415,7 +23853,6 @@
                                     {
                                         "key": "K03",
                                         "name": "K03",
-                                        "visible": false,
                                         "description": "Other diseases of hard tissues of teeth"
                                     }
                                 ]
@@ -24478,7 +23915,6 @@
                                     {
                                         "key": "K04",
                                         "name": "K04",
-                                        "visible": false,
                                         "description": "Diseases of pulp and periapical tissues"
                                     }
                                 ]
@@ -24526,7 +23962,6 @@
                                     {
                                         "key": "K05",
                                         "name": "K05",
-                                        "visible": false,
                                         "description": "Gingivitis and periodontal diseases"
                                     }
                                 ]
@@ -24564,7 +23999,6 @@
                                     {
                                         "key": "K06",
                                         "name": "K06",
-                                        "visible": false,
                                         "description": "Other disorders of gingiva and edentulous alveolar ridge"
                                     }
                                 ]
@@ -24622,7 +24056,6 @@
                                     {
                                         "key": "K07",
                                         "name": "K07",
-                                        "visible": false,
                                         "description": "Dentofacial anomalies [including malocclusion]"
                                     }
                                 ]
@@ -24665,7 +24098,6 @@
                                     {
                                         "key": "K08",
                                         "name": "K08",
-                                        "visible": false,
                                         "description": "Other disorders of teeth and supporting structures"
                                     }
                                 ]
@@ -24703,7 +24135,6 @@
                                     {
                                         "key": "K09",
                                         "name": "K09",
-                                        "visible": false,
                                         "description": "Cysts of oral region, not elsewhere classified"
                                     }
                                 ]
@@ -24746,7 +24177,6 @@
                                     {
                                         "key": "K10",
                                         "name": "K10",
-                                        "visible": false,
                                         "description": "Other diseases of jaws"
                                     }
                                 ]
@@ -24809,7 +24239,6 @@
                                     {
                                         "key": "K11",
                                         "name": "K11",
-                                        "visible": false,
                                         "description": "Diseases of salivary glands"
                                     }
                                 ]
@@ -24842,7 +24271,6 @@
                                     {
                                         "key": "K12",
                                         "name": "K12",
-                                        "visible": false,
                                         "description": "Stomatitis and related lesions"
                                     }
                                 ]
@@ -24895,7 +24323,6 @@
                                     {
                                         "key": "K13",
                                         "name": "K13",
-                                        "visible": false,
                                         "description": "Other diseases of lip and oral mucosa"
                                     }
                                 ]
@@ -24953,7 +24380,6 @@
                                     {
                                         "key": "K14",
                                         "name": "K14",
-                                        "visible": false,
                                         "description": "Diseases of tongue"
                                     }
                                 ]
@@ -24981,7 +24407,6 @@
                                     {
                                         "key": "K21",
                                         "name": "K21",
-                                        "visible": false,
                                         "description": "Gastro-oesophageal reflux disease"
                                     }
                                 ]
@@ -25044,7 +24469,6 @@
                                     {
                                         "key": "K22",
                                         "name": "K22",
-                                        "visible": false,
                                         "description": "Other diseases of oesophagus"
                                     }
                                 ]
@@ -25127,7 +24551,6 @@
                                     {
                                         "key": "K29",
                                         "name": "K29",
-                                        "visible": false,
                                         "description": "Gastritis and duodenitis"
                                     }
                                 ]
@@ -25195,7 +24618,6 @@
                                     {
                                         "key": "K31",
                                         "name": "K31",
-                                        "visible": false,
                                         "description": "Other diseases of stomach and duodenum"
                                     }
                                 ]
@@ -25223,7 +24645,6 @@
                                     {
                                         "key": "K35",
                                         "name": "K35",
-                                        "visible": false,
                                         "description": "Acute appendicitis"
                                     }
                                 ]
@@ -25276,7 +24697,6 @@
                                     {
                                         "key": "K38",
                                         "name": "K38",
-                                        "visible": false,
                                         "description": "Other diseases of appendix"
                                     }
                                 ]
@@ -25319,7 +24739,6 @@
                                     {
                                         "key": "K40",
                                         "name": "K40",
-                                        "visible": false,
                                         "description": "Inguinal hernia"
                                     }
                                 ]
@@ -25362,7 +24781,6 @@
                                     {
                                         "key": "K41",
                                         "name": "K41",
-                                        "visible": false,
                                         "description": "Femoral hernia"
                                     }
                                 ]
@@ -25390,7 +24808,6 @@
                                     {
                                         "key": "K42",
                                         "name": "K42",
-                                        "visible": false,
                                         "description": "Umbilical hernia"
                                     }
                                 ]
@@ -25448,7 +24865,6 @@
                                     {
                                         "key": "K43",
                                         "name": "K43",
-                                        "visible": false,
                                         "description": "Ventral hernia"
                                     }
                                 ]
@@ -25476,7 +24892,6 @@
                                     {
                                         "key": "K44",
                                         "name": "K44",
-                                        "visible": false,
                                         "description": "Diaphragmatic hernia"
                                     }
                                 ]
@@ -25504,7 +24919,6 @@
                                     {
                                         "key": "K45",
                                         "name": "K45",
-                                        "visible": false,
                                         "description": "Other abdominal hernia"
                                     }
                                 ]
@@ -25532,7 +24946,6 @@
                                     {
                                         "key": "K46",
                                         "name": "K46",
-                                        "visible": false,
                                         "description": "Unspecified abdominal hernia"
                                     }
                                 ]
@@ -25565,7 +24978,6 @@
                                     {
                                         "key": "K50",
                                         "name": "K50",
-                                        "visible": false,
                                         "description": "Crohn disease [regional enteritis]"
                                     }
                                 ]
@@ -25613,7 +25025,6 @@
                                     {
                                         "key": "K51",
                                         "name": "K51",
-                                        "visible": false,
                                         "description": "Ulcerative colitis"
                                     }
                                 ]
@@ -25656,7 +25067,6 @@
                                     {
                                         "key": "K52",
                                         "name": "K52",
-                                        "visible": false,
                                         "description": "Other noninfective gastroenteritis and colitis"
                                     }
                                 ]
@@ -25699,7 +25109,6 @@
                                     {
                                         "key": "K55",
                                         "name": "K55",
-                                        "visible": false,
                                         "description": "Vascular disorders of intestine"
                                     }
                                 ]
@@ -25752,7 +25161,6 @@
                                     {
                                         "key": "K56",
                                         "name": "K56",
-                                        "visible": false,
                                         "description": "Paralytic ileus and intestinal obstruction without hernia"
                                     }
                                 ]
@@ -25805,7 +25213,6 @@
                                     {
                                         "key": "K57",
                                         "name": "K57",
-                                        "visible": false,
                                         "description": "Diverticular disease of intestine"
                                     }
                                 ]
@@ -25838,7 +25245,6 @@
                                     {
                                         "key": "K58",
                                         "name": "K58",
-                                        "visible": false,
                                         "description": "Irritable bowel syndrome"
                                     }
                                 ]
@@ -25886,7 +25292,6 @@
                                     {
                                         "key": "K59",
                                         "name": "K59",
-                                        "visible": false,
                                         "description": "Other functional intestinal disorders"
                                     }
                                 ]
@@ -25929,7 +25334,6 @@
                                     {
                                         "key": "K60",
                                         "name": "K60",
-                                        "visible": false,
                                         "description": "Fissure and fistula of anal and rectal regions"
                                     }
                                 ]
@@ -25967,7 +25371,6 @@
                                     {
                                         "key": "K61",
                                         "name": "K61",
-                                        "visible": false,
                                         "description": "Abscess of anal and rectal regions"
                                     }
                                 ]
@@ -26030,7 +25433,6 @@
                                     {
                                         "key": "K62",
                                         "name": "K62",
-                                        "visible": false,
                                         "description": "Other diseases of anus and rectum"
                                     }
                                 ]
@@ -26083,7 +25485,6 @@
                                     {
                                         "key": "K63",
                                         "name": "K63",
-                                        "visible": false,
                                         "description": "Other diseases of intestine"
                                     }
                                 ]
@@ -26136,7 +25537,6 @@
                                     {
                                         "key": "K64",
                                         "name": "K64",
-                                        "visible": false,
                                         "description": "Haemorrhoids and perianal venous thrombosis"
                                     }
                                 ]
@@ -26164,7 +25564,6 @@
                                     {
                                         "key": "K65",
                                         "name": "K65",
-                                        "visible": false,
                                         "description": "Peritonitis"
                                     }
                                 ]
@@ -26202,7 +25601,6 @@
                                     {
                                         "key": "K66",
                                         "name": "K66",
-                                        "visible": false,
                                         "description": "Other disorders of peritoneum"
                                     }
                                 ]
@@ -26245,7 +25643,6 @@
                                     {
                                         "key": "K70",
                                         "name": "K70",
-                                        "visible": false,
                                         "description": "Alcoholic liver disease"
                                     }
                                 ]
@@ -26308,7 +25705,6 @@
                                     {
                                         "key": "K71",
                                         "name": "K71",
-                                        "visible": false,
                                         "description": "Toxic liver disease"
                                     }
                                 ]
@@ -26336,7 +25732,6 @@
                                     {
                                         "key": "K72",
                                         "name": "K72",
-                                        "visible": false,
                                         "description": "Hepatic failure, not elsewhere classified"
                                     }
                                 ]
@@ -26374,7 +25769,6 @@
                                     {
                                         "key": "K73",
                                         "name": "K73",
-                                        "visible": false,
                                         "description": "Chronic hepatitis, not elsewhere classified"
                                     }
                                 ]
@@ -26422,7 +25816,6 @@
                                     {
                                         "key": "K74",
                                         "name": "K74",
-                                        "visible": false,
                                         "description": "Fibrosis and cirrhosis of liver"
                                     }
                                 ]
@@ -26470,7 +25863,6 @@
                                     {
                                         "key": "K75",
                                         "name": "K75",
-                                        "visible": false,
                                         "description": "Other inflammatory liver diseases"
                                     }
                                 ]
@@ -26533,7 +25925,6 @@
                                     {
                                         "key": "K76",
                                         "name": "K76",
-                                        "visible": false,
                                         "description": "Other diseases of liver"
                                     }
                                 ]
@@ -26581,7 +25972,6 @@
                                     {
                                         "key": "K80",
                                         "name": "K80",
-                                        "visible": false,
                                         "description": "Cholelithiasis"
                                     }
                                 ]
@@ -26614,7 +26004,6 @@
                                     {
                                         "key": "K81",
                                         "name": "K81",
-                                        "visible": false,
                                         "description": "Cholecystitis"
                                     }
                                 ]
@@ -26662,7 +26051,6 @@
                                     {
                                         "key": "K82",
                                         "name": "K82",
-                                        "visible": false,
                                         "description": "Other diseases of gallbladder"
                                     }
                                 ]
@@ -26715,7 +26103,6 @@
                                     {
                                         "key": "K83",
                                         "name": "K83",
-                                        "visible": false,
                                         "description": "Other diseases of biliary tract"
                                     }
                                 ]
@@ -26758,7 +26145,6 @@
                                     {
                                         "key": "K85",
                                         "name": "K85",
-                                        "visible": false,
                                         "description": "Acute pancreatitis"
                                     }
                                 ]
@@ -26801,7 +26187,6 @@
                                     {
                                         "key": "K86",
                                         "name": "K86",
-                                        "visible": false,
                                         "description": "Other diseases of pancreas"
                                     }
                                 ]
@@ -26849,7 +26234,6 @@
                                     {
                                         "key": "K90",
                                         "name": "K90",
-                                        "visible": false,
                                         "description": "Intestinal malabsorption"
                                     }
                                 ]
@@ -26902,7 +26286,6 @@
                                     {
                                         "key": "K91",
                                         "name": "K91",
-                                        "visible": false,
                                         "description": "Postprocedural disorders of digestive system, not elsewhere classified"
                                     }
                                 ]
@@ -26940,7 +26323,6 @@
                                     {
                                         "key": "K92",
                                         "name": "K92",
-                                        "visible": false,
                                         "description": "Other diseases of digestive system"
                                     }
                                 ]
@@ -26975,7 +26357,6 @@
                                     {
                                         "key": "L01",
                                         "name": "L01",
-                                        "visible": false,
                                         "description": "Impetigo"
                                     }
                                 ]
@@ -27023,7 +26404,6 @@
                                     {
                                         "key": "L02",
                                         "name": "L02",
-                                        "visible": false,
                                         "description": "Cutaneous abscess, furuncle and carbuncle"
                                     }
                                 ]
@@ -27066,7 +26446,6 @@
                                     {
                                         "key": "L03",
                                         "name": "L03",
-                                        "visible": false,
                                         "description": "Cellulitis"
                                     }
                                 ]
@@ -27109,7 +26488,6 @@
                                     {
                                         "key": "L04",
                                         "name": "L04",
-                                        "visible": false,
                                         "description": "Acute lymphadenitis"
                                     }
                                 ]
@@ -27132,7 +26510,6 @@
                                     {
                                         "key": "L05",
                                         "name": "L05",
-                                        "visible": false,
                                         "description": "Pilonidal cyst"
                                     }
                                 ]
@@ -27165,7 +26542,6 @@
                                     {
                                         "key": "L08",
                                         "name": "L08",
-                                        "visible": false,
                                         "description": "Other local infections of skin and subcutaneous tissue"
                                     }
                                 ]
@@ -27218,7 +26594,6 @@
                                     {
                                         "key": "L10",
                                         "name": "L10",
-                                        "visible": false,
                                         "description": "Pemphigus"
                                     }
                                 ]
@@ -27251,7 +26626,6 @@
                                     {
                                         "key": "L11",
                                         "name": "L11",
-                                        "visible": false,
                                         "description": "Other acantholytic disorders"
                                     }
                                 ]
@@ -27294,7 +26668,6 @@
                                     {
                                         "key": "L12",
                                         "name": "L12",
-                                        "visible": false,
                                         "description": "Pemphigoid"
                                     }
                                 ]
@@ -27327,7 +26700,6 @@
                                     {
                                         "key": "L13",
                                         "name": "L13",
-                                        "visible": false,
                                         "description": "Other bullous disorders"
                                     }
                                 ]
@@ -27355,7 +26727,6 @@
                                     {
                                         "key": "L20",
                                         "name": "L20",
-                                        "visible": false,
                                         "description": "Atopic dermatitis"
                                     }
                                 ]
@@ -27388,7 +26759,6 @@
                                     {
                                         "key": "L21",
                                         "name": "L21",
-                                        "visible": false,
                                         "description": "Seborrhoeic dermatitis"
                                     }
                                 ]
@@ -27456,7 +26826,6 @@
                                     {
                                         "key": "L23",
                                         "name": "L23",
-                                        "visible": false,
                                         "description": "Allergic contact dermatitis"
                                     }
                                 ]
@@ -27519,7 +26888,6 @@
                                     {
                                         "key": "L24",
                                         "name": "L24",
-                                        "visible": false,
                                         "description": "Irritant contact dermatitis"
                                     }
                                 ]
@@ -27572,7 +26940,6 @@
                                     {
                                         "key": "L25",
                                         "name": "L25",
-                                        "visible": false,
                                         "description": "Unspecified contact dermatitis"
                                     }
                                 ]
@@ -27615,7 +26982,6 @@
                                     {
                                         "key": "L27",
                                         "name": "L27",
-                                        "visible": false,
                                         "description": "Dermatitis due to substances taken internally"
                                     }
                                 ]
@@ -27643,7 +27009,6 @@
                                     {
                                         "key": "L28",
                                         "name": "L28",
-                                        "visible": false,
                                         "description": "Lichen simplex chronicus and prurigo"
                                     }
                                 ]
@@ -27686,7 +27051,6 @@
                                     {
                                         "key": "L29",
                                         "name": "L29",
-                                        "visible": false,
                                         "description": "Pruritus"
                                     }
                                 ]
@@ -27739,7 +27103,6 @@
                                     {
                                         "key": "L30",
                                         "name": "L30",
-                                        "visible": false,
                                         "description": "Other dermatitis"
                                     }
                                 ]
@@ -27787,7 +27150,6 @@
                                     {
                                         "key": "L40",
                                         "name": "L40",
-                                        "visible": false,
                                         "description": "Psoriasis"
                                     }
                                 ]
@@ -27835,7 +27197,6 @@
                                     {
                                         "key": "L41",
                                         "name": "L41",
-                                        "visible": false,
                                         "description": "Parapsoriasis"
                                     }
                                 ]
@@ -27883,7 +27244,6 @@
                                     {
                                         "key": "L43",
                                         "name": "L43",
-                                        "visible": false,
                                         "description": "Lichen planus"
                                     }
                                 ]
@@ -27931,7 +27291,6 @@
                                     {
                                         "key": "L44",
                                         "name": "L44",
-                                        "visible": false,
                                         "description": "Other papulosquamous disorders"
                                     }
                                 ]
@@ -27989,7 +27348,6 @@
                                     {
                                         "key": "L50",
                                         "name": "L50",
-                                        "visible": false,
                                         "description": "Urticaria"
                                     }
                                 ]
@@ -28027,7 +27385,6 @@
                                     {
                                         "key": "L51",
                                         "name": "L51",
-                                        "visible": false,
                                         "description": "Erythema multiforme"
                                     }
                                 ]
@@ -28075,7 +27432,6 @@
                                     {
                                         "key": "L53",
                                         "name": "L53",
-                                        "visible": false,
                                         "description": "Other erythematous conditions"
                                     }
                                 ]
@@ -28113,7 +27469,6 @@
                                     {
                                         "key": "L55",
                                         "name": "L55",
-                                        "visible": false,
                                         "description": "Sunburn"
                                     }
                                 ]
@@ -28161,7 +27516,6 @@
                                     {
                                         "key": "L56",
                                         "name": "L56",
-                                        "visible": false,
                                         "description": "Other acute skin changes due to ultraviolet radiation"
                                     }
                                 ]
@@ -28214,7 +27568,6 @@
                                     {
                                         "key": "L57",
                                         "name": "L57",
-                                        "visible": false,
                                         "description": "Skin changes due to chronic exposure to nonionizing radiation"
                                     }
                                 ]
@@ -28242,7 +27595,6 @@
                                     {
                                         "key": "L58",
                                         "name": "L58",
-                                        "visible": false,
                                         "description": "Radiodermatitis"
                                     }
                                 ]
@@ -28270,7 +27622,6 @@
                                     {
                                         "key": "L59",
                                         "name": "L59",
-                                        "visible": false,
                                         "description": "Other disorders of skin and subcutaneous tissue related to radiation"
                                     }
                                 ]
@@ -28323,7 +27674,6 @@
                                     {
                                         "key": "L60",
                                         "name": "L60",
-                                        "visible": false,
                                         "description": "Nail disorders"
                                     }
                                 ]
@@ -28361,7 +27711,6 @@
                                     {
                                         "key": "L63",
                                         "name": "L63",
-                                        "visible": false,
                                         "description": "Alopecia areata"
                                     }
                                 ]
@@ -28389,7 +27738,6 @@
                                     {
                                         "key": "L64",
                                         "name": "L64",
-                                        "visible": false,
                                         "description": "Androgenic alopecia"
                                     }
                                 ]
@@ -28427,7 +27775,6 @@
                                     {
                                         "key": "L65",
                                         "name": "L65",
-                                        "visible": false,
                                         "description": "Other nonscarring hair loss"
                                     }
                                 ]
@@ -28475,7 +27822,6 @@
                                     {
                                         "key": "L66",
                                         "name": "L66",
-                                        "visible": false,
                                         "description": "Cicatricial alopecia [scarring hair loss]"
                                     }
                                 ]
@@ -28508,7 +27854,6 @@
                                     {
                                         "key": "L67",
                                         "name": "L67",
-                                        "visible": false,
                                         "description": "Hair colour and hair shaft abnormalities"
                                     }
                                 ]
@@ -28551,7 +27896,6 @@
                                     {
                                         "key": "L68",
                                         "name": "L68",
-                                        "visible": false,
                                         "description": "Hypertrichosis"
                                     }
                                 ]
@@ -28604,7 +27948,6 @@
                                     {
                                         "key": "L70",
                                         "name": "L70",
-                                        "visible": false,
                                         "description": "Acne"
                                     }
                                 ]
@@ -28637,7 +27980,6 @@
                                     {
                                         "key": "L71",
                                         "name": "L71",
-                                        "visible": false,
                                         "description": "Rosacea"
                                     }
                                 ]
@@ -28675,7 +28017,6 @@
                                     {
                                         "key": "L72",
                                         "name": "L72",
-                                        "visible": false,
                                         "description": "Follicular cysts of skin and subcutaneous tissue"
                                     }
                                 ]
@@ -28713,7 +28054,6 @@
                                     {
                                         "key": "L73",
                                         "name": "L73",
-                                        "visible": false,
                                         "description": "Other follicular disorders"
                                     }
                                 ]
@@ -28761,7 +28101,6 @@
                                     {
                                         "key": "L74",
                                         "name": "L74",
-                                        "visible": false,
                                         "description": "Eccrine sweat disorders"
                                     }
                                 ]
@@ -28799,7 +28138,6 @@
                                     {
                                         "key": "L75",
                                         "name": "L75",
-                                        "visible": false,
                                         "description": "Apocrine sweat disorders"
                                     }
                                 ]
@@ -28867,7 +28205,6 @@
                                     {
                                         "key": "L81",
                                         "name": "L81",
-                                        "visible": false,
                                         "description": "Other disorders of pigmentation"
                                     }
                                 ]
@@ -28925,7 +28262,6 @@
                                     {
                                         "key": "L85",
                                         "name": "L85",
-                                        "visible": false,
                                         "description": "Other epidermal thickening"
                                     }
                                 ]
@@ -28963,7 +28299,6 @@
                                     {
                                         "key": "L87",
                                         "name": "L87",
-                                        "visible": false,
                                         "description": "Transepidermal elimination disorders"
                                     }
                                 ]
@@ -29006,7 +28341,6 @@
                                     {
                                         "key": "L89",
                                         "name": "L89",
-                                        "visible": false,
                                         "description": "Decubitus ulcer and pressure area"
                                     }
                                 ]
@@ -29064,7 +28398,6 @@
                                     {
                                         "key": "L90",
                                         "name": "L90",
-                                        "visible": false,
                                         "description": "Atrophic disorders of skin"
                                     }
                                 ]
@@ -29092,7 +28425,6 @@
                                     {
                                         "key": "L91",
                                         "name": "L91",
-                                        "visible": false,
                                         "description": "Hypertrophic disorders of skin"
                                     }
                                 ]
@@ -29135,7 +28467,6 @@
                                     {
                                         "key": "L92",
                                         "name": "L92",
-                                        "visible": false,
                                         "description": "Granulomatous disorders of skin and subcutaneous tissue"
                                     }
                                 ]
@@ -29163,7 +28494,6 @@
                                     {
                                         "key": "L93",
                                         "name": "L93",
-                                        "visible": false,
                                         "description": "Lupus erythematosus"
                                     }
                                 ]
@@ -29221,7 +28551,6 @@
                                     {
                                         "key": "L94",
                                         "name": "L94",
-                                        "visible": false,
                                         "description": "Other localized connective tissue disorders"
                                     }
                                 ]
@@ -29254,7 +28583,6 @@
                                     {
                                         "key": "L95",
                                         "name": "L95",
-                                        "visible": false,
                                         "description": "Vasculitis limited to skin, not elsewhere classified"
                                     }
                                 ]
@@ -29322,7 +28650,6 @@
                                     {
                                         "key": "L98",
                                         "name": "L98",
-                                        "visible": false,
                                         "description": "Other disorders of skin and subcutaneous tissue, not elsewhere classified"
                                     }
                                 ]
@@ -29367,7 +28694,6 @@
                                     {
                                         "key": "M00",
                                         "name": "M00",
-                                        "visible": false,
                                         "description": "Pyogenic arthritis"
                                     }
                                 ]
@@ -29410,7 +28736,6 @@
                                     {
                                         "key": "M02",
                                         "name": "M02",
-                                        "visible": false,
                                         "description": "Reactive arthropathies"
                                     }
                                 ]
@@ -29443,7 +28768,6 @@
                                     {
                                         "key": "M05",
                                         "name": "M05",
-                                        "visible": false,
                                         "description": "Seropositive rheumatoid arthritis"
                                     }
                                 ]
@@ -29491,7 +28815,6 @@
                                     {
                                         "key": "M06",
                                         "name": "M06",
-                                        "visible": false,
                                         "description": "Other rheumatoid arthritis"
                                     }
                                 ]
@@ -29539,7 +28862,6 @@
                                     {
                                         "key": "M08",
                                         "name": "M08",
-                                        "visible": false,
                                         "description": "Juvenile arthritis"
                                     }
                                 ]
@@ -29582,7 +28904,6 @@
                                     {
                                         "key": "M10",
                                         "name": "M10",
-                                        "visible": false,
                                         "description": "Gout"
                                     }
                                 ]
@@ -29620,7 +28941,6 @@
                                     {
                                         "key": "M11",
                                         "name": "M11",
-                                        "visible": false,
                                         "description": "Other crystal arthropathies"
                                     }
                                 ]
@@ -29668,7 +28988,6 @@
                                     {
                                         "key": "M12",
                                         "name": "M12",
-                                        "visible": false,
                                         "description": "Other specific arthropathies"
                                     }
                                 ]
@@ -29701,7 +29020,6 @@
                                     {
                                         "key": "M13",
                                         "name": "M13",
-                                        "visible": false,
                                         "description": "Other arthritis"
                                     }
                                 ]
@@ -29749,7 +29067,6 @@
                                     {
                                         "key": "M15",
                                         "name": "M15",
-                                        "visible": false,
                                         "description": "Polyarthrosis"
                                     }
                                 ]
@@ -29807,7 +29124,6 @@
                                     {
                                         "key": "M16",
                                         "name": "M16",
-                                        "visible": false,
                                         "description": "Coxarthrosis [arthrosis of hip]"
                                     }
                                 ]
@@ -29855,7 +29171,6 @@
                                     {
                                         "key": "M17",
                                         "name": "M17",
-                                        "visible": false,
                                         "description": "Gonarthrosis [arthrosis of knee]"
                                     }
                                 ]
@@ -29903,7 +29218,6 @@
                                     {
                                         "key": "M18",
                                         "name": "M18",
-                                        "visible": false,
                                         "description": "Arthrosis of first carpometacarpal joint"
                                     }
                                 ]
@@ -29941,7 +29255,6 @@
                                     {
                                         "key": "M19",
                                         "name": "M19",
-                                        "visible": false,
                                         "description": "Other arthrosis"
                                     }
                                 ]
@@ -29989,7 +29302,6 @@
                                     {
                                         "key": "M20",
                                         "name": "M20",
-                                        "visible": false,
                                         "description": "Acquired deformities of fingers and toes"
                                     }
                                 ]
@@ -30052,7 +29364,6 @@
                                     {
                                         "key": "M21",
                                         "name": "M21",
-                                        "visible": false,
                                         "description": "Other acquired deformities of limbs"
                                     }
                                 ]
@@ -30100,7 +29411,6 @@
                                     {
                                         "key": "M22",
                                         "name": "M22",
-                                        "visible": false,
                                         "description": "Disorders of patella"
                                     }
                                 ]
@@ -30158,7 +29468,6 @@
                                     {
                                         "key": "M23",
                                         "name": "M23",
-                                        "visible": false,
                                         "description": "Internal derangement of knee"
                                     }
                                 ]
@@ -30221,7 +29530,6 @@
                                     {
                                         "key": "M24",
                                         "name": "M24",
-                                        "visible": false,
                                         "description": "Other specific joint derangements"
                                     }
                                 ]
@@ -30284,7 +29592,6 @@
                                     {
                                         "key": "M25",
                                         "name": "M25",
-                                        "visible": false,
                                         "description": "Other joint disorders, not elsewhere classified"
                                     }
                                 ]
@@ -30322,7 +29629,6 @@
                                     {
                                         "key": "M30",
                                         "name": "M30",
-                                        "visible": false,
                                         "description": "Polyarteritis nodosa and related conditions"
                                     }
                                 ]
@@ -30380,7 +29686,6 @@
                                     {
                                         "key": "M31",
                                         "name": "M31",
-                                        "visible": false,
                                         "description": "Other necrotizing vasculopathies"
                                     }
                                 ]
@@ -30408,7 +29713,6 @@
                                     {
                                         "key": "M32",
                                         "name": "M32",
-                                        "visible": false,
                                         "description": "Systemic lupus erythematosus"
                                     }
                                 ]
@@ -30441,7 +29745,6 @@
                                     {
                                         "key": "M33",
                                         "name": "M33",
-                                        "visible": false,
                                         "description": "Dermatopolymyositis"
                                     }
                                 ]
@@ -30479,7 +29782,6 @@
                                     {
                                         "key": "M34",
                                         "name": "M34",
-                                        "visible": false,
                                         "description": "Systemic sclerosis"
                                     }
                                 ]
@@ -30542,7 +29844,6 @@
                                     {
                                         "key": "M35",
                                         "name": "M35",
-                                        "visible": false,
                                         "description": "Other systemic involvement of connective tissue"
                                     }
                                 ]
@@ -30585,7 +29886,6 @@
                                     {
                                         "key": "M40",
                                         "name": "M40",
-                                        "visible": false,
                                         "description": "Kyphosis and lordosis"
                                     }
                                 ]
@@ -30638,7 +29938,6 @@
                                     {
                                         "key": "M41",
                                         "name": "M41",
-                                        "visible": false,
                                         "description": "Scoliosis"
                                     }
                                 ]
@@ -30666,7 +29965,6 @@
                                     {
                                         "key": "M42",
                                         "name": "M42",
-                                        "visible": false,
                                         "description": "Spinal osteochondrosis"
                                     }
                                 ]
@@ -30724,7 +30022,6 @@
                                     {
                                         "key": "M43",
                                         "name": "M43",
-                                        "visible": false,
                                         "description": "Other deforming dorsopathies"
                                     }
                                 ]
@@ -30782,7 +30079,6 @@
                                     {
                                         "key": "M46",
                                         "name": "M46",
-                                        "visible": false,
                                         "description": "Other inflammatory spondylopathies"
                                     }
                                 ]
@@ -30815,7 +30111,6 @@
                                     {
                                         "key": "M47",
                                         "name": "M47",
-                                        "visible": false,
                                         "description": "Spondylosis"
                                     }
                                 ]
@@ -30868,7 +30163,6 @@
                                     {
                                         "key": "M48",
                                         "name": "M48",
-                                        "visible": false,
                                         "description": "Other spondylopathies"
                                     }
                                 ]
@@ -30906,7 +30200,6 @@
                                     {
                                         "key": "M50",
                                         "name": "M50",
-                                        "visible": false,
                                         "description": "Cervical disc disorders"
                                     }
                                 ]
@@ -30944,7 +30237,6 @@
                                     {
                                         "key": "M51",
                                         "name": "M51",
-                                        "visible": false,
                                         "description": "Other intervertebral disc disorders"
                                     }
                                 ]
@@ -30987,7 +30279,6 @@
                                     {
                                         "key": "M53",
                                         "name": "M53",
-                                        "visible": false,
                                         "description": "Other dorsopathies, not elsewhere classified"
                                     }
                                 ]
@@ -31045,7 +30336,6 @@
                                     {
                                         "key": "M54",
                                         "name": "M54",
-                                        "visible": false,
                                         "description": "Dorsalgia"
                                     }
                                 ]
@@ -31083,7 +30373,6 @@
                                     {
                                         "key": "M60",
                                         "name": "M60",
-                                        "visible": false,
                                         "description": "Myositis"
                                     }
                                 ]
@@ -31131,7 +30420,6 @@
                                     {
                                         "key": "M61",
                                         "name": "M61",
-                                        "visible": false,
                                         "description": "Calcification and ossification of muscle"
                                     }
                                 ]
@@ -31189,7 +30477,6 @@
                                     {
                                         "key": "M62",
                                         "name": "M62",
-                                        "visible": false,
                                         "description": "Other disorders of muscle"
                                     }
                                 ]
@@ -31237,7 +30524,6 @@
                                     {
                                         "key": "M65",
                                         "name": "M65",
-                                        "visible": false,
                                         "description": "Synovitis and tenosynovitis"
                                     }
                                 ]
@@ -31280,7 +30566,6 @@
                                     {
                                         "key": "M66",
                                         "name": "M66",
-                                        "visible": false,
                                         "description": "Spontaneous rupture of synovium and tendon"
                                     }
                                 ]
@@ -31328,7 +30613,6 @@
                                     {
                                         "key": "M67",
                                         "name": "M67",
-                                        "visible": false,
                                         "description": "Other disorders of synovium and tendon"
                                     }
                                 ]
@@ -31391,7 +30675,6 @@
                                     {
                                         "key": "M70",
                                         "name": "M70",
-                                        "visible": false,
                                         "description": "Soft tissue disorders related to use, overuse and pressure"
                                     }
                                 ]
@@ -31444,7 +30727,6 @@
                                     {
                                         "key": "M71",
                                         "name": "M71",
-                                        "visible": false,
                                         "description": "Other bursopathies"
                                     }
                                 ]
@@ -31492,7 +30774,6 @@
                                     {
                                         "key": "M72",
                                         "name": "M72",
-                                        "visible": false,
                                         "description": "Fibroblastic disorders"
                                     }
                                 ]
@@ -31550,7 +30831,6 @@
                                     {
                                         "key": "M75",
                                         "name": "M75",
-                                        "visible": false,
                                         "description": "Shoulder lesions"
                                     }
                                 ]
@@ -31613,7 +30893,6 @@
                                     {
                                         "key": "M76",
                                         "name": "M76",
-                                        "visible": false,
                                         "description": "Enthesopathies of lower limb, excluding foot"
                                     }
                                 ]
@@ -31666,7 +30945,6 @@
                                     {
                                         "key": "M77",
                                         "name": "M77",
-                                        "visible": false,
                                         "description": "Other enthesopathies"
                                     }
                                 ]
@@ -31729,7 +31007,6 @@
                                     {
                                         "key": "M79",
                                         "name": "M79",
-                                        "visible": false,
                                         "description": "Other soft tissue disorders, not elsewhere classified"
                                     }
                                 ]
@@ -31782,7 +31059,6 @@
                                     {
                                         "key": "M80",
                                         "name": "M80",
-                                        "visible": false,
                                         "description": "Osteoporosis with pathological fracture"
                                     }
                                 ]
@@ -31840,7 +31116,6 @@
                                     {
                                         "key": "M81",
                                         "name": "M81",
-                                        "visible": false,
                                         "description": "Osteoporosis without pathological fracture"
                                     }
                                 ]
@@ -31893,7 +31168,6 @@
                                     {
                                         "key": "M83",
                                         "name": "M83",
-                                        "visible": false,
                                         "description": "Adult osteomalacia"
                                     }
                                 ]
@@ -31941,7 +31215,6 @@
                                     {
                                         "key": "M84",
                                         "name": "M84",
-                                        "visible": false,
                                         "description": "Disorders of continuity of bone"
                                     }
                                 ]
@@ -31999,7 +31272,6 @@
                                     {
                                         "key": "M85",
                                         "name": "M85",
-                                        "visible": false,
                                         "description": "Other disorders of bone density and structure"
                                     }
                                 ]
@@ -32057,7 +31329,6 @@
                                     {
                                         "key": "M86",
                                         "name": "M86",
-                                        "visible": false,
                                         "description": "Osteomyelitis"
                                     }
                                 ]
@@ -32100,7 +31371,6 @@
                                     {
                                         "key": "M87",
                                         "name": "M87",
-                                        "visible": false,
                                         "description": "Osteonecrosis"
                                     }
                                 ]
@@ -32128,7 +31398,6 @@
                                     {
                                         "key": "M88",
                                         "name": "M88",
-                                        "visible": false,
                                         "description": "Paget disease of bone [osteitis deformans]"
                                     }
                                 ]
@@ -32186,7 +31455,6 @@
                                     {
                                         "key": "M89",
                                         "name": "M89",
-                                        "visible": false,
                                         "description": "Other disorders of bone"
                                     }
                                 ]
@@ -32229,7 +31497,6 @@
                                     {
                                         "key": "M91",
                                         "name": "M91",
-                                        "visible": false,
                                         "description": "Juvenile osteochondrosis of hip and pelvis"
                                     }
                                 ]
@@ -32292,7 +31559,6 @@
                                     {
                                         "key": "M92",
                                         "name": "M92",
-                                        "visible": false,
                                         "description": "Other juvenile osteochondrosis"
                                     }
                                 ]
@@ -32330,7 +31596,6 @@
                                     {
                                         "key": "M93",
                                         "name": "M93",
-                                        "visible": false,
                                         "description": "Other osteochondropathies"
                                     }
                                 ]
@@ -32373,7 +31638,6 @@
                                     {
                                         "key": "M94",
                                         "name": "M94",
-                                        "visible": false,
                                         "description": "Other disorders of cartilage"
                                     }
                                 ]
@@ -32426,7 +31690,6 @@
                                     {
                                         "key": "M95",
                                         "name": "M95",
-                                        "visible": false,
                                         "description": "Other acquired deformities of musculoskeletal system and connective tissue"
                                     }
                                 ]
@@ -32484,7 +31747,6 @@
                                     {
                                         "key": "M96",
                                         "name": "M96",
-                                        "visible": false,
                                         "description": "Postprocedural musculoskeletal disorders, not elsewhere classified"
                                     }
                                 ]
@@ -32547,7 +31809,6 @@
                                     {
                                         "key": "M99",
                                         "name": "M99",
-                                        "visible": false,
                                         "description": "Biomechanical lesions, not elsewhere classified"
                                     }
                                 ]
@@ -32632,7 +31893,6 @@
                                     {
                                         "key": "N11",
                                         "name": "N11",
-                                        "visible": false,
                                         "description": "Chronic tubulo-interstitial nephritis"
                                     }
                                 ]
@@ -32700,7 +31960,6 @@
                                     {
                                         "key": "N13",
                                         "name": "N13",
-                                        "visible": false,
                                         "description": "Obstructive and reflux uropathy"
                                     }
                                 ]
@@ -32738,7 +31997,6 @@
                                     {
                                         "key": "N14",
                                         "name": "N14",
-                                        "visible": false,
                                         "description": "Drug- and heavy-metal-induced tubulo-interstitial and tubular conditions"
                                     }
                                 ]
@@ -32771,7 +32029,6 @@
                                     {
                                         "key": "N15",
                                         "name": "N15",
-                                        "visible": false,
                                         "description": "Other renal tubulo-interstitial diseases"
                                     }
                                 ]
@@ -32809,7 +32066,6 @@
                                     {
                                         "key": "N17",
                                         "name": "N17",
-                                        "visible": false,
                                         "description": "Acute renal failure"
                                     }
                                 ]
@@ -32852,7 +32108,6 @@
                                     {
                                         "key": "N18",
                                         "name": "N18",
-                                        "visible": false,
                                         "description": "Chronic kidney disease"
                                     }
                                 ]
@@ -32890,7 +32145,6 @@
                                     {
                                         "key": "N20",
                                         "name": "N20",
-                                        "visible": false,
                                         "description": "Calculus of kidney and ureter"
                                     }
                                 ]
@@ -32923,7 +32177,6 @@
                                     {
                                         "key": "N21",
                                         "name": "N21",
-                                        "visible": false,
                                         "description": "Calculus of lower urinary tract"
                                     }
                                 ]
@@ -32961,7 +32214,6 @@
                                     {
                                         "key": "N25",
                                         "name": "N25",
-                                        "visible": false,
                                         "description": "Disorders resulting from impaired renal tubular function"
                                     }
                                 ]
@@ -32994,7 +32246,6 @@
                                     {
                                         "key": "N27",
                                         "name": "N27",
-                                        "visible": false,
                                         "description": "Small kidney of unknown cause"
                                     }
                                 ]
@@ -33027,7 +32278,6 @@
                                     {
                                         "key": "N28",
                                         "name": "N28",
-                                        "visible": false,
                                         "description": "Other disorders of kidney and ureter, not elsewhere classified"
                                     }
                                 ]
@@ -33075,7 +32325,6 @@
                                     {
                                         "key": "N30",
                                         "name": "N30",
-                                        "visible": false,
                                         "description": "Cystitis"
                                     }
                                 ]
@@ -33113,7 +32362,6 @@
                                     {
                                         "key": "N31",
                                         "name": "N31",
-                                        "visible": false,
                                         "description": "Neuromuscular dysfunction of bladder, not elsewhere classified"
                                     }
                                 ]
@@ -33161,7 +32409,6 @@
                                     {
                                         "key": "N32",
                                         "name": "N32",
-                                        "visible": false,
                                         "description": "Other disorders of bladder"
                                     }
                                 ]
@@ -33194,7 +32441,6 @@
                                     {
                                         "key": "N34",
                                         "name": "N34",
-                                        "visible": false,
                                         "description": "Urethritis and urethral syndrome"
                                     }
                                 ]
@@ -33227,7 +32473,6 @@
                                     {
                                         "key": "N35",
                                         "name": "N35",
-                                        "visible": false,
                                         "description": "Urethral stricture"
                                     }
                                 ]
@@ -33270,7 +32515,6 @@
                                     {
                                         "key": "N36",
                                         "name": "N36",
-                                        "visible": false,
                                         "description": "Other disorders of urethra"
                                     }
                                 ]
@@ -33318,7 +32562,6 @@
                                     {
                                         "key": "N39",
                                         "name": "N39",
-                                        "visible": false,
                                         "description": "Other disorders of urinary system"
                                     }
                                 ]
@@ -33366,7 +32609,6 @@
                                     {
                                         "key": "N41",
                                         "name": "N41",
-                                        "visible": false,
                                         "description": "Inflammatory diseases of prostate"
                                     }
                                 ]
@@ -33409,7 +32651,6 @@
                                     {
                                         "key": "N42",
                                         "name": "N42",
-                                        "visible": false,
                                         "description": "Other disorders of prostate"
                                     }
                                 ]
@@ -33447,7 +32688,6 @@
                                     {
                                         "key": "N43",
                                         "name": "N43",
-                                        "visible": false,
                                         "description": "Hydrocele and spermatocele"
                                     }
                                 ]
@@ -33475,7 +32715,6 @@
                                     {
                                         "key": "N45",
                                         "name": "N45",
-                                        "visible": false,
                                         "description": "Orchitis and epididymitis"
                                     }
                                 ]
@@ -33543,7 +32782,6 @@
                                     {
                                         "key": "N48",
                                         "name": "N48",
-                                        "visible": false,
                                         "description": "Other disorders of penis"
                                     }
                                 ]
@@ -33581,7 +32819,6 @@
                                     {
                                         "key": "N49",
                                         "name": "N49",
-                                        "visible": false,
                                         "description": "Inflammatory disorders of male genital organs, not elsewhere classified"
                                     }
                                 ]
@@ -33614,7 +32851,6 @@
                                     {
                                         "key": "N50",
                                         "name": "N50",
-                                        "visible": false,
                                         "description": "Other disorders of male genital organs"
                                     }
                                 ]
@@ -33662,7 +32898,6 @@
                                     {
                                         "key": "N60",
                                         "name": "N60",
-                                        "visible": false,
                                         "description": "Benign mammary dysplasia"
                                     }
                                 ]
@@ -33730,7 +32965,6 @@
                                     {
                                         "key": "N64",
                                         "name": "N64",
-                                        "visible": false,
                                         "description": "Other disorders of breast"
                                     }
                                 ]
@@ -33758,7 +32992,6 @@
                                     {
                                         "key": "N70",
                                         "name": "N70",
-                                        "visible": false,
                                         "description": "Salpingitis and oophoritis"
                                     }
                                 ]
@@ -33786,7 +33019,6 @@
                                     {
                                         "key": "N71",
                                         "name": "N71",
-                                        "visible": false,
                                         "description": "Inflammatory disease of uterus, except cervix"
                                     }
                                 ]
@@ -33849,7 +33081,6 @@
                                     {
                                         "key": "N73",
                                         "name": "N73",
-                                        "visible": false,
                                         "description": "Other female pelvic inflammatory diseases"
                                     }
                                 ]
@@ -33882,7 +33113,6 @@
                                     {
                                         "key": "N75",
                                         "name": "N75",
-                                        "visible": false,
                                         "description": "Diseases of Bartholin gland"
                                     }
                                 ]
@@ -33935,7 +33165,6 @@
                                     {
                                         "key": "N76",
                                         "name": "N76",
-                                        "visible": false,
                                         "description": "Other inflammation of vagina and vulva"
                                     }
                                 ]
@@ -33993,7 +33222,6 @@
                                     {
                                         "key": "N80",
                                         "name": "N80",
-                                        "visible": false,
                                         "description": "Endometriosis"
                                     }
                                 ]
@@ -34051,7 +33279,6 @@
                                     {
                                         "key": "N81",
                                         "name": "N81",
-                                        "visible": false,
                                         "description": "Female genital prolapse"
                                     }
                                 ]
@@ -34104,7 +33331,6 @@
                                     {
                                         "key": "N82",
                                         "name": "N82",
-                                        "visible": false,
                                         "description": "Fistulae involving female genital tract"
                                     }
                                 ]
@@ -34167,7 +33393,6 @@
                                     {
                                         "key": "N83",
                                         "name": "N83",
-                                        "visible": false,
                                         "description": "Noninflammatory disorders of ovary, fallopian tube and broad ligament"
                                     }
                                 ]
@@ -34210,7 +33435,6 @@
                                     {
                                         "key": "N84",
                                         "name": "N84",
-                                        "visible": false,
                                         "description": "Polyp of female genital tract"
                                     }
                                 ]
@@ -34273,7 +33497,6 @@
                                     {
                                         "key": "N85",
                                         "name": "N85",
-                                        "visible": false,
                                         "description": "Other noninflammatory disorders of uterus, except cervix"
                                     }
                                 ]
@@ -34311,7 +33534,6 @@
                                     {
                                         "key": "N87",
                                         "name": "N87",
-                                        "visible": false,
                                         "description": "Dysplasia of cervix uteri"
                                     }
                                 ]
@@ -34359,7 +33581,6 @@
                                     {
                                         "key": "N88",
                                         "name": "N88",
-                                        "visible": false,
                                         "description": "Other noninflammatory disorders of cervix uteri"
                                     }
                                 ]
@@ -34422,7 +33643,6 @@
                                     {
                                         "key": "N89",
                                         "name": "N89",
-                                        "visible": false,
                                         "description": "Other noninflammatory disorders of vagina"
                                     }
                                 ]
@@ -34485,7 +33705,6 @@
                                     {
                                         "key": "N90",
                                         "name": "N90",
-                                        "visible": false,
                                         "description": "Other noninflammatory disorders of vulva and perineum"
                                     }
                                 ]
@@ -34528,7 +33747,6 @@
                                     {
                                         "key": "N91",
                                         "name": "N91",
-                                        "visible": false,
                                         "description": "Absent, scanty and rare menstruation"
                                     }
                                 ]
@@ -34576,7 +33794,6 @@
                                     {
                                         "key": "N92",
                                         "name": "N92",
-                                        "visible": false,
                                         "description": "Excessive, frequent and irregular menstruation"
                                     }
                                 ]
@@ -34604,7 +33821,6 @@
                                     {
                                         "key": "N93",
                                         "name": "N93",
-                                        "visible": false,
                                         "description": "Other abnormal uterine and vaginal bleeding"
                                     }
                                 ]
@@ -34662,7 +33878,6 @@
                                     {
                                         "key": "N94",
                                         "name": "N94",
-                                        "visible": false,
                                         "description": "Pain and other conditions associated with female genital organs and menstrual cycle"
                                     }
                                 ]
@@ -34705,7 +33920,6 @@
                                     {
                                         "key": "N95",
                                         "name": "N95",
-                                        "visible": false,
                                         "description": "Menopausal and other perimenopausal disorders"
                                     }
                                 ]
@@ -34758,7 +33972,6 @@
                                     {
                                         "key": "N97",
                                         "name": "N97",
-                                        "visible": false,
                                         "description": "Female infertility"
                                     }
                                 ]
@@ -34801,7 +34014,6 @@
                                     {
                                         "key": "N98",
                                         "name": "N98",
-                                        "visible": false,
                                         "description": "Complications associated with artificial fertilization"
                                     }
                                 ]
@@ -34854,7 +34066,6 @@
                                     {
                                         "key": "N99",
                                         "name": "N99",
-                                        "visible": false,
                                         "description": "Postprocedural disorders of genitourinary system, not elsewhere classified"
                                     }
                                 ]
@@ -34899,7 +34110,6 @@
                                     {
                                         "key": "O00",
                                         "name": "O00",
-                                        "visible": false,
                                         "description": "Ectopic pregnancy"
                                     }
                                 ]
@@ -34927,7 +34137,6 @@
                                     {
                                         "key": "O01",
                                         "name": "O01",
-                                        "visible": false,
                                         "description": "Hydatidiform mole"
                                     }
                                 ]
@@ -34960,7 +34169,6 @@
                                     {
                                         "key": "O02",
                                         "name": "O02",
-                                        "visible": false,
                                         "description": "Other abnormal products of conception"
                                     }
                                 ]
@@ -35043,7 +34251,6 @@
                                     {
                                         "key": "O07",
                                         "name": "O07",
-                                        "visible": false,
                                         "description": "Failed attempted abortion"
                                     }
                                 ]
@@ -35106,7 +34313,6 @@
                                     {
                                         "key": "O08",
                                         "name": "O08",
-                                        "visible": false,
                                         "description": "Complications following abortion and ectopic and molar pregnancy"
                                     }
                                 ]
@@ -35149,7 +34355,6 @@
                                     {
                                         "key": "O10",
                                         "name": "O10",
-                                        "visible": false,
                                         "description": "Pre-existing hypertension complicating pregnancy, childbirth and the puerperium"
                                     }
                                 ]
@@ -35182,7 +34387,6 @@
                                     {
                                         "key": "O12",
                                         "name": "O12",
-                                        "visible": false,
                                         "description": "Gestational [pregnancy-induced] oedema and proteinuria without hypertension"
                                     }
                                 ]
@@ -35220,7 +34424,6 @@
                                     {
                                         "key": "O14",
                                         "name": "O14",
-                                        "visible": false,
                                         "description": "Pre-eclampsia"
                                     }
                                 ]
@@ -35253,7 +34456,6 @@
                                     {
                                         "key": "O15",
                                         "name": "O15",
-                                        "visible": false,
                                         "description": "Eclampsia"
                                     }
                                 ]
@@ -35286,7 +34488,6 @@
                                     {
                                         "key": "O20",
                                         "name": "O20",
-                                        "visible": false,
                                         "description": "Haemorrhage in early pregnancy"
                                     }
                                 ]
@@ -35324,7 +34525,6 @@
                                     {
                                         "key": "O21",
                                         "name": "O21",
-                                        "visible": false,
                                         "description": "Excessive vomiting in pregnancy"
                                     }
                                 ]
@@ -35377,7 +34577,6 @@
                                     {
                                         "key": "O22",
                                         "name": "O22",
-                                        "visible": false,
                                         "description": "Venous complications and haemorrhoids in pregnancy"
                                     }
                                 ]
@@ -35425,7 +34624,6 @@
                                     {
                                         "key": "O23",
                                         "name": "O23",
-                                        "visible": false,
                                         "description": "Infections of genitourinary tract in pregnancy"
                                     }
                                 ]
@@ -35468,7 +34666,6 @@
                                     {
                                         "key": "O24",
                                         "name": "O24",
-                                        "visible": false,
                                         "description": "Diabetes mellitus in pregnancy"
                                     }
                                 ]
@@ -35536,7 +34733,6 @@
                                     {
                                         "key": "O26",
                                         "name": "O26",
-                                        "visible": false,
                                         "description": "Maternal care for other conditions predominantly related to pregnancy"
                                     }
                                 ]
@@ -35589,7 +34785,6 @@
                                     {
                                         "key": "O28",
                                         "name": "O28",
-                                        "visible": false,
                                         "description": "Abnormal findings on antenatal screening of mother"
                                     }
                                 ]
@@ -35647,7 +34842,6 @@
                                     {
                                         "key": "O29",
                                         "name": "O29",
-                                        "visible": false,
                                         "description": "Complications of anaesthesia during pregnancy"
                                     }
                                 ]
@@ -35685,7 +34879,6 @@
                                     {
                                         "key": "O30",
                                         "name": "O30",
-                                        "visible": false,
                                         "description": "Multiple gestation"
                                     }
                                 ]
@@ -35718,7 +34911,6 @@
                                     {
                                         "key": "O31",
                                         "name": "O31",
-                                        "visible": false,
                                         "description": "Complications specific to multiple gestation"
                                     }
                                 ]
@@ -35776,7 +34968,6 @@
                                     {
                                         "key": "O32",
                                         "name": "O32",
-                                        "visible": false,
                                         "description": "Maternal care for known or suspected malpresentation of fetus"
                                     }
                                 ]
@@ -35839,7 +35030,6 @@
                                     {
                                         "key": "O33",
                                         "name": "O33",
-                                        "visible": false,
                                         "description": "Maternal care for known or suspected disproportion"
                                     }
                                 ]
@@ -35902,7 +35092,6 @@
                                     {
                                         "key": "O34",
                                         "name": "O34",
-                                        "visible": false,
                                         "description": "Maternal care for known or suspected abnormality of pelvic organs"
                                     }
                                 ]
@@ -35965,7 +35154,6 @@
                                     {
                                         "key": "O35",
                                         "name": "O35",
-                                        "visible": false,
                                         "description": "Maternal care for known or suspected fetal abnormality and damage"
                                     }
                                 ]
@@ -36028,7 +35216,6 @@
                                     {
                                         "key": "O36",
                                         "name": "O36",
-                                        "visible": false,
                                         "description": "Maternal care for other known or suspected fetal problems"
                                     }
                                 ]
@@ -36066,7 +35253,6 @@
                                     {
                                         "key": "O41",
                                         "name": "O41",
-                                        "visible": false,
                                         "description": "Other disorders of amniotic fluid and membranes"
                                     }
                                 ]
@@ -36099,7 +35285,6 @@
                                     {
                                         "key": "O42",
                                         "name": "O42",
-                                        "visible": false,
                                         "description": "Premature rupture of membranes"
                                     }
                                 ]
@@ -36137,7 +35322,6 @@
                                     {
                                         "key": "O43",
                                         "name": "O43",
-                                        "visible": false,
                                         "description": "Placental disorders"
                                     }
                                 ]
@@ -36160,7 +35344,6 @@
                                     {
                                         "key": "O44",
                                         "name": "O44",
-                                        "visible": false,
                                         "description": "Placenta praevia"
                                     }
                                 ]
@@ -36188,7 +35371,6 @@
                                     {
                                         "key": "O45",
                                         "name": "O45",
-                                        "visible": false,
                                         "description": "Premature separation of placenta [abruptio placentae]"
                                     }
                                 ]
@@ -36216,7 +35398,6 @@
                                     {
                                         "key": "O46",
                                         "name": "O46",
-                                        "visible": false,
                                         "description": "Antepartum haemorrhage, not elsewhere classified"
                                     }
                                 ]
@@ -36244,7 +35425,6 @@
                                     {
                                         "key": "O47",
                                         "name": "O47",
-                                        "visible": false,
                                         "description": "False labour"
                                     }
                                 ]
@@ -36282,7 +35462,6 @@
                                     {
                                         "key": "O60",
                                         "name": "O60",
-                                        "visible": false,
                                         "description": "Preterm labour and delivery"
                                     }
                                 ]
@@ -36315,7 +35494,6 @@
                                     {
                                         "key": "O61",
                                         "name": "O61",
-                                        "visible": false,
                                         "description": "Failed induction of labour"
                                     }
                                 ]
@@ -36363,7 +35541,6 @@
                                     {
                                         "key": "O62",
                                         "name": "O62",
-                                        "visible": false,
                                         "description": "Abnormalities of forces of labour"
                                     }
                                 ]
@@ -36396,7 +35573,6 @@
                                     {
                                         "key": "O63",
                                         "name": "O63",
-                                        "visible": false,
                                         "description": "Long labour"
                                     }
                                 ]
@@ -36449,7 +35625,6 @@
                                     {
                                         "key": "O64",
                                         "name": "O64",
-                                        "visible": false,
                                         "description": "Obstructed labour due to malposition and malpresentation of fetus"
                                     }
                                 ]
@@ -36502,7 +35677,6 @@
                                     {
                                         "key": "O65",
                                         "name": "O65",
-                                        "visible": false,
                                         "description": "Obstructed labour due to maternal pelvic abnormality"
                                     }
                                 ]
@@ -36555,7 +35729,6 @@
                                     {
                                         "key": "O66",
                                         "name": "O66",
-                                        "visible": false,
                                         "description": "Other obstructed labour"
                                     }
                                 ]
@@ -36583,7 +35756,6 @@
                                     {
                                         "key": "O67",
                                         "name": "O67",
-                                        "visible": false,
                                         "description": "Labour and delivery complicated by intrapartum haemorrhage, not elsewhere classified"
                                     }
                                 ]
@@ -36626,7 +35798,6 @@
                                     {
                                         "key": "O68",
                                         "name": "O68",
-                                        "visible": false,
                                         "description": "Labour and delivery complicated by fetal stress [distress]"
                                     }
                                 ]
@@ -36679,7 +35850,6 @@
                                     {
                                         "key": "O69",
                                         "name": "O69",
-                                        "visible": false,
                                         "description": "Labour and delivery complicated by umbilical cord complications"
                                     }
                                 ]
@@ -36717,7 +35887,6 @@
                                     {
                                         "key": "O70",
                                         "name": "O70",
-                                        "visible": false,
                                         "description": "Perineal laceration during delivery"
                                     }
                                 ]
@@ -36780,7 +35949,6 @@
                                     {
                                         "key": "O71",
                                         "name": "O71",
-                                        "visible": false,
                                         "description": "Other obstetric trauma"
                                     }
                                 ]
@@ -36813,7 +35981,6 @@
                                     {
                                         "key": "O72",
                                         "name": "O72",
-                                        "visible": false,
                                         "description": "Postpartum haemorrhage"
                                     }
                                 ]
@@ -36836,7 +36003,6 @@
                                     {
                                         "key": "O73",
                                         "name": "O73",
-                                        "visible": false,
                                         "description": "Retained placenta and membranes, without haemorrhage"
                                     }
                                 ]
@@ -36899,7 +36065,6 @@
                                     {
                                         "key": "O74",
                                         "name": "O74",
-                                        "visible": false,
                                         "description": "Complications of anaesthesia during labour and delivery"
                                     }
                                 ]
@@ -36962,7 +36127,6 @@
                                     {
                                         "key": "O75",
                                         "name": "O75",
-                                        "visible": false,
                                         "description": "Other complications of labour and delivery, not elsewhere classified"
                                     }
                                 ]
@@ -37025,7 +36189,6 @@
                                     {
                                         "key": "O86",
                                         "name": "O86",
-                                        "visible": false,
                                         "description": "Other puerperal infections"
                                     }
                                 ]
@@ -37068,7 +36231,6 @@
                                     {
                                         "key": "O87",
                                         "name": "O87",
-                                        "visible": false,
                                         "description": "Venous complications and haemorrhoids in the puerperium"
                                     }
                                 ]
@@ -37106,7 +36268,6 @@
                                     {
                                         "key": "O88",
                                         "name": "O88",
-                                        "visible": false,
                                         "description": "Obstetric embolism"
                                     }
                                 ]
@@ -37164,7 +36325,6 @@
                                     {
                                         "key": "O89",
                                         "name": "O89",
-                                        "visible": false,
                                         "description": "Complications of anaesthesia during the puerperium"
                                     }
                                 ]
@@ -37217,7 +36377,6 @@
                                     {
                                         "key": "O90",
                                         "name": "O90",
-                                        "visible": false,
                                         "description": "Complications of the puerperium, not elsewhere classified"
                                     }
                                 ]
@@ -37245,7 +36404,6 @@
                                     {
                                         "key": "O91",
                                         "name": "O91",
-                                        "visible": false,
                                         "description": "Infections of breast associated with childbirth"
                                     }
                                 ]
@@ -37298,7 +36456,6 @@
                                     {
                                         "key": "O92",
                                         "name": "O92",
-                                        "visible": false,
                                         "description": "Other disorders of breast and lactation associated with childbirth"
                                     }
                                 ]
@@ -37336,7 +36493,6 @@
                                     {
                                         "key": "O96",
                                         "name": "O96",
-                                        "visible": false,
                                         "description": "Death from any obstetric cause occurring more than 42 days but less than one year after delivery"
                                     }
                                 ]
@@ -37364,7 +36520,6 @@
                                     {
                                         "key": "O97",
                                         "name": "O97",
-                                        "visible": false,
                                         "description": "Death from sequelae of obstetric causes"
                                     }
                                 ]
@@ -37427,7 +36582,6 @@
                                     {
                                         "key": "O98",
                                         "name": "O98",
-                                        "visible": false,
                                         "description": "Maternal infectious and parasitic diseases classifiable elsewhere but complicating pregnancy, childbirth and the puerperium"
                                     }
                                 ]
@@ -37485,7 +36639,6 @@
                                     {
                                         "key": "O99",
                                         "name": "O99",
-                                        "visible": false,
                                         "description": "Other maternal diseases classifiable elsewhere but complicating pregnancy, childbirth and the puerperium"
                                     }
                                 ]
@@ -37555,7 +36708,6 @@
                                     {
                                         "key": "P00",
                                         "name": "P00",
-                                        "visible": false,
                                         "description": "Fetus and newborn affected by maternal conditions that may be unrelated to present pregnancy"
                                     }
                                 ]
@@ -37618,7 +36770,6 @@
                                     {
                                         "key": "P01",
                                         "name": "P01",
-                                        "visible": false,
                                         "description": "Fetus and newborn affected by maternal complications of pregnancy"
                                     }
                                 ]
@@ -37681,7 +36832,6 @@
                                     {
                                         "key": "P02",
                                         "name": "P02",
-                                        "visible": false,
                                         "description": "Fetus and newborn affected by complications of placenta, cord and membranes"
                                     }
                                 ]
@@ -37739,7 +36889,6 @@
                                     {
                                         "key": "P03",
                                         "name": "P03",
-                                        "visible": false,
                                         "description": "Fetus and newborn affected by other complications of labour and delivery"
                                     }
                                 ]
@@ -37797,7 +36946,6 @@
                                     {
                                         "key": "P04",
                                         "name": "P04",
-                                        "visible": false,
                                         "description": "Fetus and newborn affected by noxious influences transmitted via placenta or breast milk"
                                     }
                                 ]
@@ -37830,7 +36978,6 @@
                                     {
                                         "key": "P05",
                                         "name": "P05",
-                                        "visible": false,
                                         "description": "Slow fetal growth and fetal malnutrition"
                                     }
                                 ]
@@ -37863,7 +37010,6 @@
                                     {
                                         "key": "P07",
                                         "name": "P07",
-                                        "visible": false,
                                         "description": "Disorders related to short gestation and low birth weight, not elsewhere classified"
                                     }
                                 ]
@@ -37891,7 +37037,6 @@
                                     {
                                         "key": "P08",
                                         "name": "P08",
-                                        "visible": false,
                                         "description": "Disorders related to long gestation and high birth weight"
                                     }
                                 ]
@@ -37939,7 +37084,6 @@
                                     {
                                         "key": "P10",
                                         "name": "P10",
-                                        "visible": false,
                                         "description": "Intracranial laceration and haemorrhage due to birth injury"
                                     }
                                 ]
@@ -37987,7 +37131,6 @@
                                     {
                                         "key": "P11",
                                         "name": "P11",
-                                        "visible": false,
                                         "description": "Other birth injuries to central nervous system"
                                     }
                                 ]
@@ -38035,7 +37178,6 @@
                                     {
                                         "key": "P12",
                                         "name": "P12",
-                                        "visible": false,
                                         "description": "Birth injury to scalp"
                                     }
                                 ]
@@ -38083,7 +37225,6 @@
                                     {
                                         "key": "P13",
                                         "name": "P13",
-                                        "visible": false,
                                         "description": "Birth injury to skeleton"
                                     }
                                 ]
@@ -38126,7 +37267,6 @@
                                     {
                                         "key": "P14",
                                         "name": "P14",
-                                        "visible": false,
                                         "description": "Birth injury to peripheral nervous system"
                                     }
                                 ]
@@ -38184,7 +37324,6 @@
                                     {
                                         "key": "P15",
                                         "name": "P15",
-                                        "visible": false,
                                         "description": "Other birth injuries"
                                     }
                                 ]
@@ -38212,7 +37351,6 @@
                                     {
                                         "key": "P20",
                                         "name": "P20",
-                                        "visible": false,
                                         "description": "Intrauterine hypoxia"
                                     }
                                 ]
@@ -38240,7 +37378,6 @@
                                     {
                                         "key": "P21",
                                         "name": "P21",
-                                        "visible": false,
                                         "description": "Birth asphyxia"
                                     }
                                 ]
@@ -38273,7 +37410,6 @@
                                     {
                                         "key": "P22",
                                         "name": "P22",
-                                        "visible": false,
                                         "description": "Respiratory distress of newborn"
                                     }
                                 ]
@@ -38331,7 +37467,6 @@
                                     {
                                         "key": "P23",
                                         "name": "P23",
-                                        "visible": false,
                                         "description": "Congenital pneumonia"
                                     }
                                 ]
@@ -38374,7 +37509,6 @@
                                     {
                                         "key": "P24",
                                         "name": "P24",
-                                        "visible": false,
                                         "description": "Neonatal aspiration syndromes"
                                     }
                                 ]
@@ -38412,7 +37546,6 @@
                                     {
                                         "key": "P25",
                                         "name": "P25",
-                                        "visible": false,
                                         "description": "Interstitial emphysema and related conditions originating in the perinatal period"
                                     }
                                 ]
@@ -38445,7 +37578,6 @@
                                     {
                                         "key": "P26",
                                         "name": "P26",
-                                        "visible": false,
                                         "description": "Pulmonary haemorrhage originating in the perinatal period"
                                     }
                                 ]
@@ -38478,7 +37610,6 @@
                                     {
                                         "key": "P27",
                                         "name": "P27",
-                                        "visible": false,
                                         "description": "Chronic respiratory disease originating in the perinatal period"
                                     }
                                 ]
@@ -38531,7 +37662,6 @@
                                     {
                                         "key": "P28",
                                         "name": "P28",
-                                        "visible": false,
                                         "description": "Other respiratory conditions originating in the perinatal period"
                                     }
                                 ]
@@ -38579,7 +37709,6 @@
                                     {
                                         "key": "P29",
                                         "name": "P29",
-                                        "visible": false,
                                         "description": "Cardiovascular disorders originating in the perinatal period"
                                     }
                                 ]
@@ -38627,7 +37756,6 @@
                                     {
                                         "key": "P35",
                                         "name": "P35",
-                                        "visible": false,
                                         "description": "Congenital viral diseases"
                                     }
                                 ]
@@ -38680,7 +37808,6 @@
                                     {
                                         "key": "P36",
                                         "name": "P36",
-                                        "visible": false,
                                         "description": "Bacterial sepsis of newborn"
                                     }
                                 ]
@@ -38733,7 +37860,6 @@
                                     {
                                         "key": "P37",
                                         "name": "P37",
-                                        "visible": false,
                                         "description": "Other congenital infectious and parasitic diseases"
                                     }
                                 ]
@@ -38786,7 +37912,6 @@
                                     {
                                         "key": "P39",
                                         "name": "P39",
-                                        "visible": false,
                                         "description": "Other infections specific to the perinatal period"
                                     }
                                 ]
@@ -38839,7 +37964,6 @@
                                     {
                                         "key": "P50",
                                         "name": "P50",
-                                        "visible": false,
                                         "description": "Fetal blood loss"
                                     }
                                 ]
@@ -38867,7 +37991,6 @@
                                     {
                                         "key": "P51",
                                         "name": "P51",
-                                        "visible": false,
                                         "description": "Umbilical haemorrhage of newborn"
                                     }
                                 ]
@@ -38925,7 +38048,6 @@
                                     {
                                         "key": "P52",
                                         "name": "P52",
-                                        "visible": false,
                                         "description": "Intracranial nontraumatic haemorrhage of fetus and newborn"
                                     }
                                 ]
@@ -38988,7 +38110,6 @@
                                     {
                                         "key": "P54",
                                         "name": "P54",
-                                        "visible": false,
                                         "description": "Other neonatal haemorrhages"
                                     }
                                 ]
@@ -39021,7 +38142,6 @@
                                     {
                                         "key": "P55",
                                         "name": "P55",
-                                        "visible": false,
                                         "description": "Haemolytic disease of fetus and newborn"
                                     }
                                 ]
@@ -39044,7 +38164,6 @@
                                     {
                                         "key": "P56",
                                         "name": "P56",
-                                        "visible": false,
                                         "description": "Hydrops fetalis due to haemolytic disease"
                                     }
                                 ]
@@ -39072,7 +38191,6 @@
                                     {
                                         "key": "P57",
                                         "name": "P57",
-                                        "visible": false,
                                         "description": "Kernicterus"
                                     }
                                 ]
@@ -39125,7 +38243,6 @@
                                     {
                                         "key": "P58",
                                         "name": "P58",
-                                        "visible": false,
                                         "description": "Neonatal jaundice due to other excessive haemolysis"
                                     }
                                 ]
@@ -39168,7 +38285,6 @@
                                     {
                                         "key": "P59",
                                         "name": "P59",
-                                        "visible": false,
                                         "description": "Neonatal jaundice from other and unspecified causes"
                                     }
                                 ]
@@ -39231,7 +38347,6 @@
                                     {
                                         "key": "P61",
                                         "name": "P61",
-                                        "visible": false,
                                         "description": "Other perinatal haematological disorders"
                                     }
                                 ]
@@ -39279,7 +38394,6 @@
                                     {
                                         "key": "P70",
                                         "name": "P70",
-                                        "visible": false,
                                         "description": "Transitory disorders of carbohydrate metabolism specific to fetus and newborn"
                                     }
                                 ]
@@ -39327,7 +38441,6 @@
                                     {
                                         "key": "P71",
                                         "name": "P71",
-                                        "visible": false,
                                         "description": "Transitory neonatal disorders of calcium and magnesium metabolism"
                                     }
                                 ]
@@ -39365,7 +38478,6 @@
                                     {
                                         "key": "P72",
                                         "name": "P72",
-                                        "visible": false,
                                         "description": "Other transitory neonatal endocrine disorders"
                                     }
                                 ]
@@ -39418,7 +38530,6 @@
                                     {
                                         "key": "P74",
                                         "name": "P74",
-                                        "visible": false,
                                         "description": "Other transitory neonatal electrolyte and metabolic disturbances"
                                     }
                                 ]
@@ -39456,7 +38567,6 @@
                                     {
                                         "key": "P76",
                                         "name": "P76",
-                                        "visible": false,
                                         "description": "Other intestinal obstruction of newborn"
                                     }
                                 ]
@@ -39504,7 +38614,6 @@
                                     {
                                         "key": "P78",
                                         "name": "P78",
-                                        "visible": false,
                                         "description": "Other perinatal digestive system disorders"
                                     }
                                 ]
@@ -39532,7 +38641,6 @@
                                     {
                                         "key": "P80",
                                         "name": "P80",
-                                        "visible": false,
                                         "description": "Hypothermia of newborn"
                                     }
                                 ]
@@ -39560,7 +38668,6 @@
                                     {
                                         "key": "P81",
                                         "name": "P81",
-                                        "visible": false,
                                         "description": "Other disturbances of temperature regulation of newborn"
                                     }
                                 ]
@@ -39618,7 +38725,6 @@
                                     {
                                         "key": "P83",
                                         "name": "P83",
-                                        "visible": false,
                                         "description": "Other conditions of integument specific to fetus and newborn"
                                     }
                                 ]
@@ -39686,7 +38792,6 @@
                                     {
                                         "key": "P91",
                                         "name": "P91",
-                                        "visible": false,
                                         "description": "Other disturbances of cerebral status of newborn"
                                     }
                                 ]
@@ -39739,7 +38844,6 @@
                                     {
                                         "key": "P92",
                                         "name": "P92",
-                                        "visible": false,
                                         "description": "Feeding problems of newborn"
                                     }
                                 ]
@@ -39782,7 +38886,6 @@
                                     {
                                         "key": "P94",
                                         "name": "P94",
-                                        "visible": false,
                                         "description": "Disorders of muscle tone of newborn"
                                     }
                                 ]
@@ -39840,7 +38943,6 @@
                                     {
                                         "key": "P96",
                                         "name": "P96",
-                                        "visible": false,
                                         "description": "Other conditions originating in the perinatal period"
                                     }
                                 ]
@@ -39875,7 +38977,6 @@
                                     {
                                         "key": "Q00",
                                         "name": "Q00",
-                                        "visible": false,
                                         "description": "Anencephaly and similar malformations"
                                     }
                                 ]
@@ -39913,7 +39014,6 @@
                                     {
                                         "key": "Q01",
                                         "name": "Q01",
-                                        "visible": false,
                                         "description": "Encephalocele"
                                     }
                                 ]
@@ -39951,7 +39051,6 @@
                                     {
                                         "key": "Q03",
                                         "name": "Q03",
-                                        "visible": false,
                                         "description": "Congenital hydrocephalus"
                                     }
                                 ]
@@ -40009,7 +39108,6 @@
                                     {
                                         "key": "Q04",
                                         "name": "Q04",
-                                        "visible": false,
                                         "description": "Other congenital malformations of brain"
                                     }
                                 ]
@@ -40072,7 +39170,6 @@
                                     {
                                         "key": "Q05",
                                         "name": "Q05",
-                                        "visible": false,
                                         "description": "Spina bifida"
                                     }
                                 ]
@@ -40120,7 +39217,6 @@
                                     {
                                         "key": "Q06",
                                         "name": "Q06",
-                                        "visible": false,
                                         "description": "Other congenital malformations of spinal cord"
                                     }
                                 ]
@@ -40148,7 +39244,6 @@
                                     {
                                         "key": "Q07",
                                         "name": "Q07",
-                                        "visible": false,
                                         "description": "Other congenital malformations of nervous system"
                                     }
                                 ]
@@ -40201,7 +39296,6 @@
                                     {
                                         "key": "Q10",
                                         "name": "Q10",
-                                        "visible": false,
                                         "description": "Congenital malformations of eyelid, lacrimal apparatus and orbit"
                                     }
                                 ]
@@ -40234,7 +39328,6 @@
                                     {
                                         "key": "Q11",
                                         "name": "Q11",
-                                        "visible": false,
                                         "description": "Anophthalmos, microphthalmos and macrophthalmos"
                                     }
                                 ]
@@ -40282,7 +39375,6 @@
                                     {
                                         "key": "Q12",
                                         "name": "Q12",
-                                        "visible": false,
                                         "description": "Congenital lens malformations"
                                     }
                                 ]
@@ -40335,7 +39427,6 @@
                                     {
                                         "key": "Q13",
                                         "name": "Q13",
-                                        "visible": false,
                                         "description": "Congenital malformations of anterior segment of eye"
                                     }
                                 ]
@@ -40378,7 +39469,6 @@
                                     {
                                         "key": "Q14",
                                         "name": "Q14",
-                                        "visible": false,
                                         "description": "Congenital malformations of posterior segment of eye"
                                     }
                                 ]
@@ -40406,7 +39496,6 @@
                                     {
                                         "key": "Q15",
                                         "name": "Q15",
-                                        "visible": false,
                                         "description": "Other congenital malformations of eye"
                                     }
                                 ]
@@ -40454,7 +39543,6 @@
                                     {
                                         "key": "Q16",
                                         "name": "Q16",
-                                        "visible": false,
                                         "description": "Congenital malformations of ear causing impairment of hearing"
                                     }
                                 ]
@@ -40507,7 +39595,6 @@
                                     {
                                         "key": "Q17",
                                         "name": "Q17",
-                                        "visible": false,
                                         "description": "Other congenital malformations of ear"
                                     }
                                 ]
@@ -40570,7 +39657,6 @@
                                     {
                                         "key": "Q18",
                                         "name": "Q18",
-                                        "visible": false,
                                         "description": "Other congenital malformations of face and neck"
                                     }
                                 ]
@@ -40628,7 +39714,6 @@
                                     {
                                         "key": "Q20",
                                         "name": "Q20",
-                                        "visible": false,
                                         "description": "Congenital malformations of cardiac chambers and connections"
                                     }
                                 ]
@@ -40676,7 +39761,6 @@
                                     {
                                         "key": "Q21",
                                         "name": "Q21",
-                                        "visible": false,
                                         "description": "Congenital malformations of cardiac septa"
                                     }
                                 ]
@@ -40734,7 +39818,6 @@
                                     {
                                         "key": "Q22",
                                         "name": "Q22",
-                                        "visible": false,
                                         "description": "Congenital malformations of pulmonary and tricuspid valves"
                                     }
                                 ]
@@ -40782,7 +39865,6 @@
                                     {
                                         "key": "Q23",
                                         "name": "Q23",
-                                        "visible": false,
                                         "description": "Congenital malformations of aortic and mitral valves"
                                     }
                                 ]
@@ -40840,7 +39922,6 @@
                                     {
                                         "key": "Q24",
                                         "name": "Q24",
-                                        "visible": false,
                                         "description": "Other congenital malformations of heart"
                                     }
                                 ]
@@ -40903,7 +39984,6 @@
                                     {
                                         "key": "Q25",
                                         "name": "Q25",
-                                        "visible": false,
                                         "description": "Congenital malformations of great arteries"
                                     }
                                 ]
@@ -40961,7 +40041,6 @@
                                     {
                                         "key": "Q26",
                                         "name": "Q26",
-                                        "visible": false,
                                         "description": "Congenital malformations of great veins"
                                     }
                                 ]
@@ -41009,7 +40088,6 @@
                                     {
                                         "key": "Q27",
                                         "name": "Q27",
-                                        "visible": false,
                                         "description": "Other congenital malformations of peripheral vascular system"
                                     }
                                 ]
@@ -41052,7 +40130,6 @@
                                     {
                                         "key": "Q28",
                                         "name": "Q28",
-                                        "visible": false,
                                         "description": "Other congenital malformations of circulatory system"
                                     }
                                 ]
@@ -41095,7 +40172,6 @@
                                     {
                                         "key": "Q30",
                                         "name": "Q30",
-                                        "visible": false,
                                         "description": "Congenital malformations of nose"
                                     }
                                 ]
@@ -41143,7 +40219,6 @@
                                     {
                                         "key": "Q31",
                                         "name": "Q31",
-                                        "visible": false,
                                         "description": "Congenital malformations of larynx"
                                     }
                                 ]
@@ -41181,7 +40256,6 @@
                                     {
                                         "key": "Q32",
                                         "name": "Q32",
-                                        "visible": false,
                                         "description": "Congenital malformations of trachea and bronchus"
                                     }
                                 ]
@@ -41239,7 +40313,6 @@
                                     {
                                         "key": "Q33",
                                         "name": "Q33",
-                                        "visible": false,
                                         "description": "Congenital malformations of lung"
                                     }
                                 ]
@@ -41272,7 +40345,6 @@
                                     {
                                         "key": "Q34",
                                         "name": "Q34",
-                                        "visible": false,
                                         "description": "Other congenital malformations of respiratory system"
                                     }
                                 ]
@@ -41310,7 +40382,6 @@
                                     {
                                         "key": "Q35",
                                         "name": "Q35",
-                                        "visible": false,
                                         "description": "Cleft palate"
                                     }
                                 ]
@@ -41338,7 +40409,6 @@
                                     {
                                         "key": "Q36",
                                         "name": "Q36",
-                                        "visible": false,
                                         "description": "Cleft lip"
                                     }
                                 ]
@@ -41391,7 +40461,6 @@
                                     {
                                         "key": "Q37",
                                         "name": "Q37",
-                                        "visible": false,
                                         "description": "Cleft palate with cleft lip"
                                     }
                                 ]
@@ -41449,7 +40518,6 @@
                                     {
                                         "key": "Q38",
                                         "name": "Q38",
-                                        "visible": false,
                                         "description": "Other congenital malformations of tongue, mouth and pharynx"
                                     }
                                 ]
@@ -41507,7 +40575,6 @@
                                     {
                                         "key": "Q39",
                                         "name": "Q39",
-                                        "visible": false,
                                         "description": "Congenital malformations of oesophagus"
                                     }
                                 ]
@@ -41550,7 +40617,6 @@
                                     {
                                         "key": "Q40",
                                         "name": "Q40",
-                                        "visible": false,
                                         "description": "Other congenital malformations of upper alimentary tract"
                                     }
                                 ]
@@ -41588,7 +40654,6 @@
                                     {
                                         "key": "Q41",
                                         "name": "Q41",
-                                        "visible": false,
                                         "description": "Congenital absence, atresia and stenosis of small intestine"
                                     }
                                 ]
@@ -41631,7 +40696,6 @@
                                     {
                                         "key": "Q42",
                                         "name": "Q42",
-                                        "visible": false,
                                         "description": "Congenital absence, atresia and stenosis of large intestine"
                                     }
                                 ]
@@ -41694,7 +40758,6 @@
                                     {
                                         "key": "Q43",
                                         "name": "Q43",
-                                        "visible": false,
                                         "description": "Other congenital malformations of intestine"
                                     }
                                 ]
@@ -41747,7 +40810,6 @@
                                     {
                                         "key": "Q44",
                                         "name": "Q44",
-                                        "visible": false,
                                         "description": "Congenital malformations of gallbladder, bile ducts and liver"
                                     }
                                 ]
@@ -41790,7 +40852,6 @@
                                     {
                                         "key": "Q45",
                                         "name": "Q45",
-                                        "visible": false,
                                         "description": "Other congenital malformations of digestive system"
                                     }
                                 ]
@@ -41838,7 +40899,6 @@
                                     {
                                         "key": "Q50",
                                         "name": "Q50",
-                                        "visible": false,
                                         "description": "Congenital malformations of ovaries, fallopian tubes and broad ligaments"
                                     }
                                 ]
@@ -41901,7 +40961,6 @@
                                     {
                                         "key": "Q51",
                                         "name": "Q51",
-                                        "visible": false,
                                         "description": "Congenital malformations of uterus and cervix"
                                     }
                                 ]
@@ -41964,7 +41023,6 @@
                                     {
                                         "key": "Q52",
                                         "name": "Q52",
-                                        "visible": false,
                                         "description": "Other congenital malformations of female genitalia"
                                     }
                                 ]
@@ -41997,7 +41055,6 @@
                                     {
                                         "key": "Q53",
                                         "name": "Q53",
-                                        "visible": false,
                                         "description": "Undescended testicle"
                                     }
                                 ]
@@ -42045,7 +41102,6 @@
                                     {
                                         "key": "Q54",
                                         "name": "Q54",
-                                        "visible": false,
                                         "description": "Hypospadias"
                                     }
                                 ]
@@ -42103,7 +41159,6 @@
                                     {
                                         "key": "Q55",
                                         "name": "Q55",
-                                        "visible": false,
                                         "description": "Other congenital malformations of male genital organs"
                                     }
                                 ]
@@ -42141,7 +41196,6 @@
                                     {
                                         "key": "Q56",
                                         "name": "Q56",
-                                        "visible": false,
                                         "description": "Indeterminate sex and pseudohermaphroditism"
                                     }
                                 ]
@@ -42189,7 +41243,6 @@
                                     {
                                         "key": "Q60",
                                         "name": "Q60",
-                                        "visible": false,
                                         "description": "Renal agenesis and other reduction defects of kidney"
                                     }
                                 ]
@@ -42242,7 +41295,6 @@
                                     {
                                         "key": "Q61",
                                         "name": "Q61",
-                                        "visible": false,
                                         "description": "Cystic kidney disease"
                                     }
                                 ]
@@ -42300,7 +41352,6 @@
                                     {
                                         "key": "Q62",
                                         "name": "Q62",
-                                        "visible": false,
                                         "description": "Congenital obstructive defects of renal pelvis and congenital malformations of ureter"
                                     }
                                 ]
@@ -42343,7 +41394,6 @@
                                     {
                                         "key": "Q63",
                                         "name": "Q63",
-                                        "visible": false,
                                         "description": "Other congenital malformations of kidney"
                                     }
                                 ]
@@ -42406,7 +41456,6 @@
                                     {
                                         "key": "Q64",
                                         "name": "Q64",
-                                        "visible": false,
                                         "description": "Other congenital malformations of urinary system"
                                     }
                                 ]
@@ -42464,7 +41513,6 @@
                                     {
                                         "key": "Q65",
                                         "name": "Q65",
-                                        "visible": false,
                                         "description": "Congenital deformities of hip"
                                     }
                                 ]
@@ -42527,7 +41575,6 @@
                                     {
                                         "key": "Q66",
                                         "name": "Q66",
-                                        "visible": false,
                                         "description": "Congenital deformities of feet"
                                     }
                                 ]
@@ -42585,7 +41632,6 @@
                                     {
                                         "key": "Q67",
                                         "name": "Q67",
-                                        "visible": false,
                                         "description": "Congenital musculoskeletal deformities of head, face, spine and chest"
                                     }
                                 ]
@@ -42633,7 +41679,6 @@
                                     {
                                         "key": "Q68",
                                         "name": "Q68",
-                                        "visible": false,
                                         "description": "Other congenital musculoskeletal deformities"
                                     }
                                 ]
@@ -42666,7 +41711,6 @@
                                     {
                                         "key": "Q69",
                                         "name": "Q69",
-                                        "visible": false,
                                         "description": "Polydactyly"
                                     }
                                 ]
@@ -42709,7 +41753,6 @@
                                     {
                                         "key": "Q70",
                                         "name": "Q70",
-                                        "visible": false,
                                         "description": "Syndactyly"
                                     }
                                 ]
@@ -42767,7 +41810,6 @@
                                     {
                                         "key": "Q71",
                                         "name": "Q71",
-                                        "visible": false,
                                         "description": "Reduction defects of upper limb"
                                     }
                                 ]
@@ -42830,7 +41872,6 @@
                                     {
                                         "key": "Q72",
                                         "name": "Q72",
-                                        "visible": false,
                                         "description": "Reduction defects of lower limb"
                                     }
                                 ]
@@ -42858,7 +41899,6 @@
                                     {
                                         "key": "Q73",
                                         "name": "Q73",
-                                        "visible": false,
                                         "description": "Reduction defects of unspecified limb"
                                     }
                                 ]
@@ -42901,7 +41941,6 @@
                                     {
                                         "key": "Q74",
                                         "name": "Q74",
-                                        "visible": false,
                                         "description": "Other congenital malformations of limb(s)"
                                     }
                                 ]
@@ -42954,7 +41993,6 @@
                                     {
                                         "key": "Q75",
                                         "name": "Q75",
-                                        "visible": false,
                                         "description": "Other congenital malformations of skull and face bones"
                                     }
                                 ]
@@ -43017,7 +42055,6 @@
                                     {
                                         "key": "Q76",
                                         "name": "Q76",
-                                        "visible": false,
                                         "description": "Congenital malformations of spine and bony thorax"
                                     }
                                 ]
@@ -43080,7 +42117,6 @@
                                     {
                                         "key": "Q77",
                                         "name": "Q77",
-                                        "visible": false,
                                         "description": "Osteochondrodysplasia with defects of growth of tubular bones and spine"
                                     }
                                 ]
@@ -43138,7 +42174,6 @@
                                     {
                                         "key": "Q78",
                                         "name": "Q78",
-                                        "visible": false,
                                         "description": "Other osteochondrodysplasias"
                                     }
                                 ]
@@ -43196,7 +42231,6 @@
                                     {
                                         "key": "Q79",
                                         "name": "Q79",
-                                        "visible": false,
                                         "description": "Congenital malformations of the musculoskeletal system, not elsewhere classified"
                                     }
                                 ]
@@ -43244,7 +42278,6 @@
                                     {
                                         "key": "Q80",
                                         "name": "Q80",
-                                        "visible": false,
                                         "description": "Congenital ichthyosis"
                                     }
                                 ]
@@ -43282,7 +42315,6 @@
                                     {
                                         "key": "Q81",
                                         "name": "Q81",
-                                        "visible": false,
                                         "description": "Epidermolysis bullosa"
                                     }
                                 ]
@@ -43335,7 +42367,6 @@
                                     {
                                         "key": "Q82",
                                         "name": "Q82",
-                                        "visible": false,
                                         "description": "Other congenital malformations of skin"
                                     }
                                 ]
@@ -43378,7 +42409,6 @@
                                     {
                                         "key": "Q83",
                                         "name": "Q83",
-                                        "visible": false,
                                         "description": "Congenital malformations of breast"
                                     }
                                 ]
@@ -43436,7 +42466,6 @@
                                     {
                                         "key": "Q84",
                                         "name": "Q84",
-                                        "visible": false,
                                         "description": "Other congenital malformations of integument"
                                     }
                                 ]
@@ -43469,7 +42498,6 @@
                                     {
                                         "key": "Q85",
                                         "name": "Q85",
-                                        "visible": false,
                                         "description": "Phakomatoses, not elsewhere classified"
                                     }
                                 ]
@@ -43502,7 +42530,6 @@
                                     {
                                         "key": "Q86",
                                         "name": "Q86",
-                                        "visible": false,
                                         "description": "Congenital malformation syndromes due to known exogenous causes, not elsewhere classified"
                                     }
                                 ]
@@ -43550,7 +42577,6 @@
                                     {
                                         "key": "Q87",
                                         "name": "Q87",
-                                        "visible": false,
                                         "description": "Other specified congenital malformation syndromes affecting multiple systems"
                                     }
                                 ]
@@ -43603,7 +42629,6 @@
                                     {
                                         "key": "Q89",
                                         "name": "Q89",
-                                        "visible": false,
                                         "description": "Other congenital malformations, not elsewhere classified"
                                     }
                                 ]
@@ -43636,7 +42661,6 @@
                                     {
                                         "key": "Q90",
                                         "name": "Q90",
-                                        "visible": false,
                                         "description": "Down syndrome"
                                     }
                                 ]
@@ -43689,7 +42713,6 @@
                                     {
                                         "key": "Q91",
                                         "name": "Q91",
-                                        "visible": false,
                                         "description": "Edwards syndrome and Patau syndrome"
                                     }
                                 ]
@@ -43752,7 +42775,6 @@
                                     {
                                         "key": "Q92",
                                         "name": "Q92",
-                                        "visible": false,
                                         "description": "Other trisomies and partial trisomies of the autosomes, not elsewhere classified"
                                     }
                                 ]
@@ -43815,7 +42837,6 @@
                                     {
                                         "key": "Q93",
                                         "name": "Q93",
-                                        "visible": false,
                                         "description": "Monosomies and deletions from the autosomes, not elsewhere classified"
                                     }
                                 ]
@@ -43868,7 +42889,6 @@
                                     {
                                         "key": "Q95",
                                         "name": "Q95",
-                                        "visible": false,
                                         "description": "Balanced rearrangements and structural markers, not elsewhere classified"
                                     }
                                 ]
@@ -43916,7 +42936,6 @@
                                     {
                                         "key": "Q96",
                                         "name": "Q96",
-                                        "visible": false,
                                         "description": "Turner syndrome"
                                     }
                                 ]
@@ -43959,7 +42978,6 @@
                                     {
                                         "key": "Q97",
                                         "name": "Q97",
-                                        "visible": false,
                                         "description": "Other sex chromosome abnormalities, female phenotype, not elsewhere classified"
                                     }
                                 ]
@@ -44022,7 +43040,6 @@
                                     {
                                         "key": "Q98",
                                         "name": "Q98",
-                                        "visible": false,
                                         "description": "Other sex chromosome abnormalities, male phenotype, not elsewhere classified"
                                     }
                                 ]
@@ -44060,7 +43077,6 @@
                                     {
                                         "key": "Q99",
                                         "name": "Q99",
-                                        "visible": false,
                                         "description": "Other chromosome abnormalities, not elsewhere classified"
                                     }
                                 ]
@@ -44105,7 +43121,6 @@
                                     {
                                         "key": "R00",
                                         "name": "R00",
-                                        "visible": false,
                                         "description": "Abnormalities of heart beat"
                                     }
                                 ]
@@ -44133,7 +43148,6 @@
                                     {
                                         "key": "R01",
                                         "name": "R01",
-                                        "visible": false,
                                         "description": "Cardiac murmurs and other cardiac sounds"
                                     }
                                 ]
@@ -44161,7 +43175,6 @@
                                     {
                                         "key": "R03",
                                         "name": "R03",
-                                        "visible": false,
                                         "description": "Abnormal blood-pressure reading, without diagnosis"
                                     }
                                 ]
@@ -44199,7 +43212,6 @@
                                     {
                                         "key": "R04",
                                         "name": "R04",
-                                        "visible": false,
                                         "description": "Haemorrhage from respiratory passages"
                                     }
                                 ]
@@ -44262,7 +43274,6 @@
                                     {
                                         "key": "R06",
                                         "name": "R06",
-                                        "visible": false,
                                         "description": "Abnormalities of breathing"
                                     }
                                 ]
@@ -44300,7 +43311,6 @@
                                     {
                                         "key": "R07",
                                         "name": "R07",
-                                        "visible": false,
                                         "description": "Pain in throat and chest"
                                     }
                                 ]
@@ -44338,7 +43348,6 @@
                                     {
                                         "key": "R09",
                                         "name": "R09",
-                                        "visible": false,
                                         "description": "Other symptoms and signs involving the circulatory and respiratory systems"
                                     }
                                 ]
@@ -44376,7 +43385,6 @@
                                     {
                                         "key": "R10",
                                         "name": "R10",
-                                        "visible": false,
                                         "description": "Abdominal and pelvic pain"
                                     }
                                 ]
@@ -44429,7 +43437,6 @@
                                     {
                                         "key": "R16",
                                         "name": "R16",
-                                        "visible": false,
                                         "description": "Hepatomegaly and splenomegaly, not elsewhere classified"
                                     }
                                 ]
@@ -44452,7 +43459,6 @@
                                     {
                                         "key": "R17",
                                         "name": "R17",
-                                        "visible": false,
                                         "description": "Hyperbilirubinaemia, with or without jaundice, not elsewhere classified"
                                     }
                                 ]
@@ -44510,7 +43516,6 @@
                                     {
                                         "key": "R19",
                                         "name": "R19",
-                                        "visible": false,
                                         "description": "Other symptoms and signs involving the digestive system and abdomen"
                                     }
                                 ]
@@ -44548,7 +43553,6 @@
                                     {
                                         "key": "R20",
                                         "name": "R20",
-                                        "visible": false,
                                         "description": "Disturbances of skin sensation"
                                     }
                                 ]
@@ -44601,7 +43605,6 @@
                                     {
                                         "key": "R22",
                                         "name": "R22",
-                                        "visible": false,
                                         "description": "Localized swelling, mass and lump of skin and subcutaneous tissue"
                                     }
                                 ]
@@ -44644,7 +43647,6 @@
                                     {
                                         "key": "R23",
                                         "name": "R23",
-                                        "visible": false,
                                         "description": "Other skin changes"
                                     }
                                 ]
@@ -44682,7 +43684,6 @@
                                     {
                                         "key": "R25",
                                         "name": "R25",
-                                        "visible": false,
                                         "description": "Abnormal involuntary movements"
                                     }
                                 ]
@@ -44720,7 +43721,6 @@
                                     {
                                         "key": "R26",
                                         "name": "R26",
-                                        "visible": false,
                                         "description": "Abnormalities of gait and mobility"
                                     }
                                 ]
@@ -44743,7 +43743,6 @@
                                     {
                                         "key": "R27",
                                         "name": "R27",
-                                        "visible": false,
                                         "description": "Other lack of coordination"
                                     }
                                 ]
@@ -44791,7 +43790,6 @@
                                     {
                                         "key": "R29",
                                         "name": "R29",
-                                        "visible": false,
                                         "description": "Other symptoms and signs involving the nervous and musculoskeletal systems"
                                     }
                                 ]
@@ -44819,7 +43817,6 @@
                                     {
                                         "key": "R30",
                                         "name": "R30",
-                                        "visible": false,
                                         "description": "Pain associated with micturition"
                                     }
                                 ]
@@ -44882,7 +43879,6 @@
                                     {
                                         "key": "R39",
                                         "name": "R39",
-                                        "visible": false,
                                         "description": "Other symptoms and signs involving the urinary system"
                                     }
                                 ]
@@ -44910,7 +43906,6 @@
                                     {
                                         "key": "R40",
                                         "name": "R40",
-                                        "visible": false,
                                         "description": "Somnolence, stupor and coma"
                                     }
                                 ]
@@ -44948,7 +43943,6 @@
                                     {
                                         "key": "R41",
                                         "name": "R41",
-                                        "visible": false,
                                         "description": "Other symptoms and signs involving cognitive functions and awareness"
                                     }
                                 ]
@@ -44986,7 +43980,6 @@
                                     {
                                         "key": "R43",
                                         "name": "R43",
-                                        "visible": false,
                                         "description": "Disturbances of smell and taste"
                                     }
                                 ]
@@ -45024,7 +44017,6 @@
                                     {
                                         "key": "R44",
                                         "name": "R44",
-                                        "visible": false,
                                         "description": "Other symptoms and signs involving general sensations and perceptions"
                                     }
                                 ]
@@ -45082,7 +44074,6 @@
                                     {
                                         "key": "R45",
                                         "name": "R45",
-                                        "visible": false,
                                         "description": "Symptoms and signs involving emotional state"
                                     }
                                 ]
@@ -45140,7 +44131,6 @@
                                     {
                                         "key": "R46",
                                         "name": "R46",
-                                        "visible": false,
                                         "description": "Symptoms and signs involving appearance and behaviour"
                                     }
                                 ]
@@ -45168,7 +44158,6 @@
                                     {
                                         "key": "R47",
                                         "name": "R47",
-                                        "visible": false,
                                         "description": "Speech disturbances, not elsewhere classified"
                                     }
                                 ]
@@ -45201,7 +44190,6 @@
                                     {
                                         "key": "R48",
                                         "name": "R48",
-                                        "visible": false,
                                         "description": "Dyslexia and other symbolic dysfunctions, not elsewhere classified"
                                     }
                                 ]
@@ -45234,7 +44222,6 @@
                                     {
                                         "key": "R49",
                                         "name": "R49",
-                                        "visible": false,
                                         "description": "Voice disturbances"
                                     }
                                 ]
@@ -45262,7 +44249,6 @@
                                     {
                                         "key": "R50",
                                         "name": "R50",
-                                        "visible": false,
                                         "description": "Fever of other and unknown origin"
                                     }
                                 ]
@@ -45300,7 +44286,6 @@
                                     {
                                         "key": "R52",
                                         "name": "R52",
-                                        "visible": false,
                                         "description": "Pain, not elsewhere classified"
                                     }
                                 ]
@@ -45338,7 +44323,6 @@
                                     {
                                         "key": "R56",
                                         "name": "R56",
-                                        "visible": false,
                                         "description": "Convulsions, not elsewhere classified"
                                     }
                                 ]
@@ -45376,7 +44360,6 @@
                                     {
                                         "key": "R57",
                                         "name": "R57",
-                                        "visible": false,
                                         "description": "Shock, not elsewhere classified"
                                     }
                                 ]
@@ -45409,7 +44392,6 @@
                                     {
                                         "key": "R59",
                                         "name": "R59",
-                                        "visible": false,
                                         "description": "Enlarged lymph nodes"
                                     }
                                 ]
@@ -45437,7 +44419,6 @@
                                     {
                                         "key": "R60",
                                         "name": "R60",
-                                        "visible": false,
                                         "description": "Oedema, not elsewhere classified"
                                     }
                                 ]
@@ -45465,7 +44446,6 @@
                                     {
                                         "key": "R61",
                                         "name": "R61",
-                                        "visible": false,
                                         "description": "Hyperhidrosis"
                                     }
                                 ]
@@ -45493,7 +44473,6 @@
                                     {
                                         "key": "R62",
                                         "name": "R62",
-                                        "visible": false,
                                         "description": "Lack of expected normal physiological development"
                                     }
                                 ]
@@ -45546,7 +44525,6 @@
                                     {
                                         "key": "R63",
                                         "name": "R63",
-                                        "visible": false,
                                         "description": "Symptoms and signs concerning food and fluid intake"
                                     }
                                 ]
@@ -45589,7 +44567,6 @@
                                     {
                                         "key": "R68",
                                         "name": "R68",
-                                        "visible": false,
                                         "description": "Other general symptoms and signs"
                                     }
                                 ]
@@ -45617,7 +44594,6 @@
                                     {
                                         "key": "R70",
                                         "name": "R70",
-                                        "visible": false,
                                         "description": "Elevated erythrocyte sedimentation rate and abnormality of plasma viscosity"
                                     }
                                 ]
@@ -45650,7 +44626,6 @@
                                     {
                                         "key": "R73",
                                         "name": "R73",
-                                        "visible": false,
                                         "description": "Elevated blood glucose level"
                                     }
                                 ]
@@ -45678,7 +44653,6 @@
                                     {
                                         "key": "R74",
                                         "name": "R74",
-                                        "visible": false,
                                         "description": "Abnormal serum enzyme levels"
                                     }
                                 ]
@@ -45721,7 +44695,6 @@
                                     {
                                         "key": "R76",
                                         "name": "R76",
-                                        "visible": false,
                                         "description": "Other abnormal immunological findings in serum"
                                     }
                                 ]
@@ -45759,7 +44732,6 @@
                                     {
                                         "key": "R77",
                                         "name": "R77",
-                                        "visible": false,
                                         "description": "Other abnormalities of plasma proteins"
                                     }
                                 ]
@@ -45822,7 +44794,6 @@
                                     {
                                         "key": "R78",
                                         "name": "R78",
-                                        "visible": false,
                                         "description": "Findings of drugs and other substances, not normally found in blood"
                                     }
                                 ]
@@ -45850,7 +44821,6 @@
                                     {
                                         "key": "R79",
                                         "name": "R79",
-                                        "visible": false,
                                         "description": "Other abnormal findings of blood chemistry"
                                     }
                                 ]
@@ -45923,7 +44893,6 @@
                                     {
                                         "key": "R82",
                                         "name": "R82",
-                                        "visible": false,
                                         "description": "Other abnormal findings in urine"
                                     }
                                 ]
@@ -45976,7 +44945,6 @@
                                     {
                                         "key": "R90",
                                         "name": "R90",
-                                        "visible": false,
                                         "description": "Abnormal findings on diagnostic imaging of central nervous system"
                                     }
                                 ]
@@ -46044,7 +45012,6 @@
                                     {
                                         "key": "R93",
                                         "name": "R93",
-                                        "visible": false,
                                         "description": "Abnormal findings on diagnostic imaging of other body structures"
                                     }
                                 ]
@@ -46102,7 +45069,6 @@
                                     {
                                         "key": "R94",
                                         "name": "R94",
-                                        "visible": false,
                                         "description": "Abnormal results of function studies"
                                     }
                                 ]
@@ -46125,7 +45091,6 @@
                                     {
                                         "key": "R95",
                                         "name": "R95",
-                                        "visible": false,
                                         "description": "Sudden infant death syndrome"
                                     }
                                 ]
@@ -46148,7 +45113,6 @@
                                     {
                                         "key": "R96",
                                         "name": "R96",
-                                        "visible": false,
                                         "description": "Other sudden death, cause unknown"
                                     }
                                 ]
@@ -46223,7 +45187,6 @@
                                     {
                                         "key": "S00",
                                         "name": "S00",
-                                        "visible": false,
                                         "description": "Superficial injury of head"
                                     }
                                 ]
@@ -46281,7 +45244,6 @@
                                     {
                                         "key": "S01",
                                         "name": "S01",
-                                        "visible": false,
                                         "description": "Open wound of head"
                                     }
                                 ]
@@ -46344,7 +45306,6 @@
                                     {
                                         "key": "S02",
                                         "name": "S02",
-                                        "visible": false,
                                         "description": "Fracture of skull and facial bones"
                                     }
                                 ]
@@ -46387,7 +45348,6 @@
                                     {
                                         "key": "S03",
                                         "name": "S03",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joints and ligaments of head"
                                     }
                                 ]
@@ -46450,7 +45410,6 @@
                                     {
                                         "key": "S04",
                                         "name": "S04",
-                                        "visible": false,
                                         "description": "Injury of cranial nerves"
                                     }
                                 ]
@@ -46513,7 +45472,6 @@
                                     {
                                         "key": "S05",
                                         "name": "S05",
-                                        "visible": false,
                                         "description": "Injury of eye and orbit"
                                     }
                                 ]
@@ -46571,7 +45529,6 @@
                                     {
                                         "key": "S06",
                                         "name": "S06",
-                                        "visible": false,
                                         "description": "Intracranial injury"
                                     }
                                 ]
@@ -46604,7 +45561,6 @@
                                     {
                                         "key": "S07",
                                         "name": "S07",
-                                        "visible": false,
                                         "description": "Crushing injury of head"
                                     }
                                 ]
@@ -46637,7 +45593,6 @@
                                     {
                                         "key": "S08",
                                         "name": "S08",
-                                        "visible": false,
                                         "description": "Traumatic amputation of part of head"
                                     }
                                 ]
@@ -46680,7 +45635,6 @@
                                     {
                                         "key": "S09",
                                         "name": "S09",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of head"
                                     }
                                 ]
@@ -46718,7 +45672,6 @@
                                     {
                                         "key": "S10",
                                         "name": "S10",
-                                        "visible": false,
                                         "description": "Superficial injury of neck"
                                     }
                                 ]
@@ -46761,7 +45714,6 @@
                                     {
                                         "key": "S11",
                                         "name": "S11",
-                                        "visible": false,
                                         "description": "Open wound of neck"
                                     }
                                 ]
@@ -46804,7 +45756,6 @@
                                     {
                                         "key": "S12",
                                         "name": "S12",
-                                        "visible": false,
                                         "description": "Fracture of neck"
                                     }
                                 ]
@@ -46852,7 +45803,6 @@
                                     {
                                         "key": "S13",
                                         "name": "S13",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joints and ligaments at neck level"
                                     }
                                 ]
@@ -46900,7 +45850,6 @@
                                     {
                                         "key": "S14",
                                         "name": "S14",
-                                        "visible": false,
                                         "description": "Injury of nerves and spinal cord at neck level"
                                     }
                                 ]
@@ -46948,7 +45897,6 @@
                                     {
                                         "key": "S15",
                                         "name": "S15",
-                                        "visible": false,
                                         "description": "Injury of blood vessels at neck level"
                                     }
                                 ]
@@ -46981,7 +45929,6 @@
                                     {
                                         "key": "S17",
                                         "name": "S17",
-                                        "visible": false,
                                         "description": "Crushing injury of neck"
                                     }
                                 ]
@@ -47014,7 +45961,6 @@
                                     {
                                         "key": "S19",
                                         "name": "S19",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of neck"
                                     }
                                 ]
@@ -47062,7 +46008,6 @@
                                     {
                                         "key": "S20",
                                         "name": "S20",
-                                        "visible": false,
                                         "description": "Superficial injury of thorax"
                                     }
                                 ]
@@ -47105,7 +46050,6 @@
                                     {
                                         "key": "S21",
                                         "name": "S21",
-                                        "visible": false,
                                         "description": "Open wound of thorax"
                                     }
                                 ]
@@ -47158,7 +46102,6 @@
                                     {
                                         "key": "S22",
                                         "name": "S22",
-                                        "visible": false,
                                         "description": "Fracture of rib(s), sternum and thoracic spine"
                                     }
                                 ]
@@ -47201,7 +46144,6 @@
                                     {
                                         "key": "S23",
                                         "name": "S23",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joints and ligaments of thorax"
                                     }
                                 ]
@@ -47249,7 +46191,6 @@
                                     {
                                         "key": "S24",
                                         "name": "S24",
-                                        "visible": false,
                                         "description": "Injury of nerves and spinal cord at thorax level"
                                     }
                                 ]
@@ -47307,7 +46248,6 @@
                                     {
                                         "key": "S25",
                                         "name": "S25",
-                                        "visible": false,
                                         "description": "Injury of blood vessels of thorax"
                                     }
                                 ]
@@ -47335,7 +46275,6 @@
                                     {
                                         "key": "S26",
                                         "name": "S26",
-                                        "visible": false,
                                         "description": "Injury of heart"
                                     }
                                 ]
@@ -47398,7 +46337,6 @@
                                     {
                                         "key": "S27",
                                         "name": "S27",
-                                        "visible": false,
                                         "description": "Injury of other and unspecified intrathoracic organs"
                                     }
                                 ]
@@ -47421,7 +46359,6 @@
                                     {
                                         "key": "S28",
                                         "name": "S28",
-                                        "visible": false,
                                         "description": "Crushing injury of thorax and traumatic amputation of part of thorax"
                                     }
                                 ]
@@ -47454,7 +46391,6 @@
                                     {
                                         "key": "S29",
                                         "name": "S29",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of thorax"
                                     }
                                 ]
@@ -47497,7 +46433,6 @@
                                     {
                                         "key": "S30",
                                         "name": "S30",
-                                        "visible": false,
                                         "description": "Superficial injury of abdomen, lower back and pelvis"
                                     }
                                 ]
@@ -47550,7 +46485,6 @@
                                     {
                                         "key": "S31",
                                         "name": "S31",
-                                        "visible": false,
                                         "description": "Open wound of abdomen, lower back and pelvis"
                                     }
                                 ]
@@ -47603,7 +46537,6 @@
                                     {
                                         "key": "S32",
                                         "name": "S32",
-                                        "visible": false,
                                         "description": "Fracture of lumbar spine and pelvis"
                                     }
                                 ]
@@ -47656,7 +46589,6 @@
                                     {
                                         "key": "S33",
                                         "name": "S33",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joints and ligaments of lumbar spine and pelvis"
                                     }
                                 ]
@@ -47709,7 +46641,6 @@
                                     {
                                         "key": "S34",
                                         "name": "S34",
-                                        "visible": false,
                                         "description": "Injury of nerves and lumbar spinal cord at abdomen, lower back and pelvis level"
                                     }
                                 ]
@@ -47767,7 +46698,6 @@
                                     {
                                         "key": "S35",
                                         "name": "S35",
-                                        "visible": false,
                                         "description": "Injury of blood vessels at abdomen, lower back and pelvis level"
                                     }
                                 ]
@@ -47830,7 +46760,6 @@
                                     {
                                         "key": "S36",
                                         "name": "S36",
-                                        "visible": false,
                                         "description": "Injury of intra-abdominal organs"
                                     }
                                 ]
@@ -47893,7 +46822,6 @@
                                     {
                                         "key": "S37",
                                         "name": "S37",
-                                        "visible": false,
                                         "description": "Injury of urinary and pelvic organs"
                                     }
                                 ]
@@ -47926,7 +46854,6 @@
                                     {
                                         "key": "S38",
                                         "name": "S38",
-                                        "visible": false,
                                         "description": "Crushing injury and traumatic amputation of part of abdomen, lower back and pelvis"
                                     }
                                 ]
@@ -47964,7 +46891,6 @@
                                     {
                                         "key": "S39",
                                         "name": "S39",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of abdomen, lower back and pelvis"
                                     }
                                 ]
@@ -47997,7 +46923,6 @@
                                     {
                                         "key": "S40",
                                         "name": "S40",
-                                        "visible": false,
                                         "description": "Superficial injury of shoulder and upper arm"
                                     }
                                 ]
@@ -48030,7 +46955,6 @@
                                     {
                                         "key": "S41",
                                         "name": "S41",
-                                        "visible": false,
                                         "description": "Open wound of shoulder and upper arm"
                                     }
                                 ]
@@ -48083,7 +47007,6 @@
                                     {
                                         "key": "S42",
                                         "name": "S42",
-                                        "visible": false,
                                         "description": "Fracture of shoulder and upper arm"
                                     }
                                 ]
@@ -48136,7 +47059,6 @@
                                     {
                                         "key": "S43",
                                         "name": "S43",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joints and ligaments of shoulder girdle"
                                     }
                                 ]
@@ -48194,7 +47116,6 @@
                                     {
                                         "key": "S44",
                                         "name": "S44",
-                                        "visible": false,
                                         "description": "Injury of nerves at shoulder and upper arm level"
                                     }
                                 ]
@@ -48242,7 +47163,6 @@
                                     {
                                         "key": "S45",
                                         "name": "S45",
-                                        "visible": false,
                                         "description": "Injury of blood vessels at shoulder and upper arm level"
                                     }
                                 ]
@@ -48290,7 +47210,6 @@
                                     {
                                         "key": "S46",
                                         "name": "S46",
-                                        "visible": false,
                                         "description": "Injury of muscle and tendon at shoulder and upper arm level"
                                     }
                                 ]
@@ -48323,7 +47242,6 @@
                                     {
                                         "key": "S48",
                                         "name": "S48",
-                                        "visible": false,
                                         "description": "Traumatic amputation of shoulder and upper arm"
                                     }
                                 ]
@@ -48351,7 +47269,6 @@
                                     {
                                         "key": "S49",
                                         "name": "S49",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of shoulder and upper arm"
                                     }
                                 ]
@@ -48389,7 +47306,6 @@
                                     {
                                         "key": "S50",
                                         "name": "S50",
-                                        "visible": false,
                                         "description": "Superficial injury of forearm"
                                     }
                                 ]
@@ -48422,7 +47338,6 @@
                                     {
                                         "key": "S51",
                                         "name": "S51",
-                                        "visible": false,
                                         "description": "Open wound of forearm"
                                     }
                                 ]
@@ -48485,7 +47400,6 @@
                                     {
                                         "key": "S52",
                                         "name": "S52",
-                                        "visible": false,
                                         "description": "Fracture of forearm"
                                     }
                                 ]
@@ -48523,7 +47437,6 @@
                                     {
                                         "key": "S53",
                                         "name": "S53",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joints and ligaments of elbow"
                                     }
                                 ]
@@ -48571,7 +47484,6 @@
                                     {
                                         "key": "S54",
                                         "name": "S54",
-                                        "visible": false,
                                         "description": "Injury of nerves at forearm level"
                                     }
                                 ]
@@ -48614,7 +47526,6 @@
                                     {
                                         "key": "S55",
                                         "name": "S55",
-                                        "visible": false,
                                         "description": "Injury of blood vessels at forearm level"
                                     }
                                 ]
@@ -48667,7 +47578,6 @@
                                     {
                                         "key": "S56",
                                         "name": "S56",
-                                        "visible": false,
                                         "description": "Injury of muscle and tendon at forearm level"
                                     }
                                 ]
@@ -48695,7 +47605,6 @@
                                     {
                                         "key": "S57",
                                         "name": "S57",
-                                        "visible": false,
                                         "description": "Crushing injury of forearm"
                                     }
                                 ]
@@ -48723,7 +47632,6 @@
                                     {
                                         "key": "S58",
                                         "name": "S58",
-                                        "visible": false,
                                         "description": "Traumatic amputation of forearm"
                                     }
                                 ]
@@ -48751,7 +47659,6 @@
                                     {
                                         "key": "S59",
                                         "name": "S59",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of forearm"
                                     }
                                 ]
@@ -48794,7 +47701,6 @@
                                     {
                                         "key": "S60",
                                         "name": "S60",
-                                        "visible": false,
                                         "description": "Superficial injury of wrist and hand"
                                     }
                                 ]
@@ -48832,7 +47738,6 @@
                                     {
                                         "key": "S61",
                                         "name": "S61",
-                                        "visible": false,
                                         "description": "Open wound of wrist and hand"
                                     }
                                 ]
@@ -48890,7 +47795,6 @@
                                     {
                                         "key": "S62",
                                         "name": "S62",
-                                        "visible": false,
                                         "description": "Fracture at wrist and hand level"
                                     }
                                 ]
@@ -48943,7 +47847,6 @@
                                     {
                                         "key": "S63",
                                         "name": "S63",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joints and ligaments at wrist and hand level"
                                     }
                                 ]
@@ -48996,7 +47899,6 @@
                                     {
                                         "key": "S64",
                                         "name": "S64",
-                                        "visible": false,
                                         "description": "Injury of nerves at wrist and hand level"
                                     }
                                 ]
@@ -49054,7 +47956,6 @@
                                     {
                                         "key": "S65",
                                         "name": "S65",
-                                        "visible": false,
                                         "description": "Injury of blood vessels at wrist and hand level"
                                     }
                                 ]
@@ -49117,7 +48018,6 @@
                                     {
                                         "key": "S66",
                                         "name": "S66",
-                                        "visible": false,
                                         "description": "Injury of muscle and tendon at wrist and hand level"
                                     }
                                 ]
@@ -49140,7 +48040,6 @@
                                     {
                                         "key": "S67",
                                         "name": "S67",
-                                        "visible": false,
                                         "description": "Crushing injury of wrist and hand"
                                     }
                                 ]
@@ -49188,7 +48087,6 @@
                                     {
                                         "key": "S68",
                                         "name": "S68",
-                                        "visible": false,
                                         "description": "Traumatic amputation of wrist and hand"
                                     }
                                 ]
@@ -49216,7 +48114,6 @@
                                     {
                                         "key": "S69",
                                         "name": "S69",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of wrist and hand"
                                     }
                                 ]
@@ -49254,7 +48151,6 @@
                                     {
                                         "key": "S70",
                                         "name": "S70",
-                                        "visible": false,
                                         "description": "Superficial injury of hip and thigh"
                                     }
                                 ]
@@ -49287,7 +48183,6 @@
                                     {
                                         "key": "S71",
                                         "name": "S71",
-                                        "visible": false,
                                         "description": "Open wound of hip and thigh"
                                     }
                                 ]
@@ -49340,7 +48235,6 @@
                                     {
                                         "key": "S72",
                                         "name": "S72",
-                                        "visible": false,
                                         "description": "Fracture of femur"
                                     }
                                 ]
@@ -49363,7 +48257,6 @@
                                     {
                                         "key": "S73",
                                         "name": "S73",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joint and ligaments of hip"
                                     }
                                 ]
@@ -49406,7 +48299,6 @@
                                     {
                                         "key": "S74",
                                         "name": "S74",
-                                        "visible": false,
                                         "description": "Injury of nerves at hip and thigh level"
                                     }
                                 ]
@@ -49449,7 +48341,6 @@
                                     {
                                         "key": "S75",
                                         "name": "S75",
-                                        "visible": false,
                                         "description": "Injury of blood vessels at hip and thigh level"
                                     }
                                 ]
@@ -49492,7 +48383,6 @@
                                     {
                                         "key": "S76",
                                         "name": "S76",
-                                        "visible": false,
                                         "description": "Injury of muscle and tendon at hip and thigh level"
                                     }
                                 ]
@@ -49520,7 +48410,6 @@
                                     {
                                         "key": "S77",
                                         "name": "S77",
-                                        "visible": false,
                                         "description": "Crushing injury of hip and thigh"
                                     }
                                 ]
@@ -49548,7 +48437,6 @@
                                     {
                                         "key": "S78",
                                         "name": "S78",
-                                        "visible": false,
                                         "description": "Traumatic amputation of hip and thigh"
                                     }
                                 ]
@@ -49576,7 +48464,6 @@
                                     {
                                         "key": "S79",
                                         "name": "S79",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of hip and thigh"
                                     }
                                 ]
@@ -49614,7 +48501,6 @@
                                     {
                                         "key": "S80",
                                         "name": "S80",
-                                        "visible": false,
                                         "description": "Superficial injury of lower leg"
                                     }
                                 ]
@@ -49647,7 +48533,6 @@
                                     {
                                         "key": "S81",
                                         "name": "S81",
-                                        "visible": false,
                                         "description": "Open wound of lower leg"
                                     }
                                 ]
@@ -49710,7 +48595,6 @@
                                     {
                                         "key": "S82",
                                         "name": "S82",
-                                        "visible": false,
                                         "description": "Fracture of lower leg, including ankle"
                                     }
                                 ]
@@ -49763,7 +48647,6 @@
                                     {
                                         "key": "S83",
                                         "name": "S83",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joints and ligaments of knee"
                                     }
                                 ]
@@ -49806,7 +48689,6 @@
                                     {
                                         "key": "S84",
                                         "name": "S84",
-                                        "visible": false,
                                         "description": "Injury of nerves at lower leg level"
                                     }
                                 ]
@@ -49864,7 +48746,6 @@
                                     {
                                         "key": "S85",
                                         "name": "S85",
-                                        "visible": false,
                                         "description": "Injury of blood vessels at lower leg level"
                                     }
                                 ]
@@ -49912,7 +48793,6 @@
                                     {
                                         "key": "S86",
                                         "name": "S86",
-                                        "visible": false,
                                         "description": "Injury of muscle and tendon at lower leg level"
                                     }
                                 ]
@@ -49935,7 +48815,6 @@
                                     {
                                         "key": "S87",
                                         "name": "S87",
-                                        "visible": false,
                                         "description": "Crushing injury of lower leg"
                                     }
                                 ]
@@ -49963,7 +48842,6 @@
                                     {
                                         "key": "S88",
                                         "name": "S88",
-                                        "visible": false,
                                         "description": "Traumatic amputation of lower leg"
                                     }
                                 ]
@@ -49991,7 +48869,6 @@
                                     {
                                         "key": "S89",
                                         "name": "S89",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of lower leg"
                                     }
                                 ]
@@ -50039,7 +48916,6 @@
                                     {
                                         "key": "S90",
                                         "name": "S90",
-                                        "visible": false,
                                         "description": "Superficial injury of ankle and foot"
                                     }
                                 ]
@@ -50077,7 +48953,6 @@
                                     {
                                         "key": "S91",
                                         "name": "S91",
-                                        "visible": false,
                                         "description": "Open wound of ankle and foot"
                                     }
                                 ]
@@ -50130,7 +49005,6 @@
                                     {
                                         "key": "S92",
                                         "name": "S92",
-                                        "visible": false,
                                         "description": "Fracture of foot, except ankle"
                                     }
                                 ]
@@ -50178,7 +49052,6 @@
                                     {
                                         "key": "S93",
                                         "name": "S93",
-                                        "visible": false,
                                         "description": "Dislocation, sprain and strain of joints and ligaments at ankle and foot level"
                                     }
                                 ]
@@ -50226,7 +49099,6 @@
                                     {
                                         "key": "S94",
                                         "name": "S94",
-                                        "visible": false,
                                         "description": "Injury of nerves at ankle and foot level"
                                     }
                                 ]
@@ -50269,7 +49141,6 @@
                                     {
                                         "key": "S95",
                                         "name": "S95",
-                                        "visible": false,
                                         "description": "Injury of blood vessels at ankle and foot level"
                                     }
                                 ]
@@ -50312,7 +49183,6 @@
                                     {
                                         "key": "S96",
                                         "name": "S96",
-                                        "visible": false,
                                         "description": "Injury of muscle and tendon at ankle and foot level"
                                     }
                                 ]
@@ -50340,7 +49210,6 @@
                                     {
                                         "key": "S97",
                                         "name": "S97",
-                                        "visible": false,
                                         "description": "Crushing injury of ankle and foot"
                                     }
                                 ]
@@ -50378,7 +49247,6 @@
                                     {
                                         "key": "S98",
                                         "name": "S98",
-                                        "visible": false,
                                         "description": "Traumatic amputation of ankle and foot"
                                     }
                                 ]
@@ -50406,7 +49274,6 @@
                                     {
                                         "key": "S99",
                                         "name": "S99",
-                                        "visible": false,
                                         "description": "Other and unspecified injuries of ankle and foot"
                                     }
                                 ]
@@ -50461,7 +49328,6 @@
                                     {
                                         "key": "T00",
                                         "name": "T00",
-                                        "visible": false,
                                         "description": "Superficial injuries involving multiple body regions"
                                     }
                                 ]
@@ -50509,7 +49375,6 @@
                                     {
                                         "key": "T01",
                                         "name": "T01",
-                                        "visible": false,
                                         "description": "Open wounds involving multiple body regions"
                                     }
                                 ]
@@ -50572,7 +49437,6 @@
                                     {
                                         "key": "T02",
                                         "name": "T02",
-                                        "visible": false,
                                         "description": "Fractures involving multiple body regions"
                                     }
                                 ]
@@ -50620,7 +49484,6 @@
                                     {
                                         "key": "T03",
                                         "name": "T03",
-                                        "visible": false,
                                         "description": "Dislocations, sprains and strains involving multiple body regions"
                                     }
                                 ]
@@ -50673,7 +49536,6 @@
                                     {
                                         "key": "T04",
                                         "name": "T04",
-                                        "visible": false,
                                         "description": "Crushing injuries involving multiple body regions"
                                     }
                                 ]
@@ -50731,7 +49593,6 @@
                                     {
                                         "key": "T05",
                                         "name": "T05",
-                                        "visible": false,
                                         "description": "Traumatic amputations involving multiple body regions"
                                     }
                                 ]
@@ -50779,7 +49640,6 @@
                                     {
                                         "key": "T06",
                                         "name": "T06",
-                                        "visible": false,
                                         "description": "Other injuries involving multiple body regions, not elsewhere classified"
                                     }
                                 ]
@@ -50847,7 +49707,6 @@
                                     {
                                         "key": "T09",
                                         "name": "T09",
-                                        "visible": false,
                                         "description": "Other injuries of spine and trunk, level unspecified"
                                     }
                                 ]
@@ -50910,7 +49769,6 @@
                                     {
                                         "key": "T11",
                                         "name": "T11",
-                                        "visible": false,
                                         "description": "Other injuries of upper limb, level unspecified"
                                     }
                                 ]
@@ -50973,7 +49831,6 @@
                                     {
                                         "key": "T13",
                                         "name": "T13",
-                                        "visible": false,
                                         "description": "Other injuries of lower limb, level unspecified"
                                     }
                                 ]
@@ -51036,7 +49893,6 @@
                                     {
                                         "key": "T14",
                                         "name": "T14",
-                                        "visible": false,
                                         "description": "Injury of unspecified body region"
                                     }
                                 ]
@@ -51069,7 +49925,6 @@
                                     {
                                         "key": "T15",
                                         "name": "T15",
-                                        "visible": false,
                                         "description": "Foreign body on external eye"
                                     }
                                 ]
@@ -51127,7 +49982,6 @@
                                     {
                                         "key": "T17",
                                         "name": "T17",
-                                        "visible": false,
                                         "description": "Foreign body in respiratory tract"
                                     }
                                 ]
@@ -51180,7 +50034,6 @@
                                     {
                                         "key": "T18",
                                         "name": "T18",
-                                        "visible": false,
                                         "description": "Foreign body in alimentary tract"
                                     }
                                 ]
@@ -51223,7 +50076,6 @@
                                     {
                                         "key": "T19",
                                         "name": "T19",
-                                        "visible": false,
                                         "description": "Foreign body in genitourinary tract"
                                     }
                                 ]
@@ -51276,7 +50128,6 @@
                                     {
                                         "key": "T20",
                                         "name": "T20",
-                                        "visible": false,
                                         "description": "Burn and corrosion of head and neck"
                                     }
                                 ]
@@ -51329,7 +50180,6 @@
                                     {
                                         "key": "T21",
                                         "name": "T21",
-                                        "visible": false,
                                         "description": "Burn and corrosion of trunk"
                                     }
                                 ]
@@ -51382,7 +50232,6 @@
                                     {
                                         "key": "T22",
                                         "name": "T22",
-                                        "visible": false,
                                         "description": "Burn and corrosion of shoulder and upper limb, except wrist and hand"
                                     }
                                 ]
@@ -51435,7 +50284,6 @@
                                     {
                                         "key": "T23",
                                         "name": "T23",
-                                        "visible": false,
                                         "description": "Burn and corrosion of wrist and hand"
                                     }
                                 ]
@@ -51488,7 +50336,6 @@
                                     {
                                         "key": "T24",
                                         "name": "T24",
-                                        "visible": false,
                                         "description": "Burn and corrosion of hip and lower limb, except ankle and foot"
                                     }
                                 ]
@@ -51541,7 +50388,6 @@
                                     {
                                         "key": "T25",
                                         "name": "T25",
-                                        "visible": false,
                                         "description": "Burn and corrosion of ankle and foot"
                                     }
                                 ]
@@ -51604,7 +50450,6 @@
                                     {
                                         "key": "T26",
                                         "name": "T26",
-                                        "visible": false,
                                         "description": "Burn and corrosion confined to eye and adnexa"
                                     }
                                 ]
@@ -51657,7 +50502,6 @@
                                     {
                                         "key": "T27",
                                         "name": "T27",
-                                        "visible": false,
                                         "description": "Burn and corrosion of respiratory tract"
                                     }
                                 ]
@@ -51720,7 +50564,6 @@
                                     {
                                         "key": "T28",
                                         "name": "T28",
-                                        "visible": false,
                                         "description": "Burn and corrosion of other internal organs"
                                     }
                                 ]
@@ -51773,7 +50616,6 @@
                                     {
                                         "key": "T29",
                                         "name": "T29",
-                                        "visible": false,
                                         "description": "Burns and corrosions of multiple body regions"
                                     }
                                 ]
@@ -51826,7 +50668,6 @@
                                     {
                                         "key": "T30",
                                         "name": "T30",
-                                        "visible": false,
                                         "description": "Burn and corrosion, body region unspecified"
                                     }
                                 ]
@@ -51889,7 +50730,6 @@
                                     {
                                         "key": "T33",
                                         "name": "T33",
-                                        "visible": false,
                                         "description": "Superficial frostbite"
                                     }
                                 ]
@@ -51952,7 +50792,6 @@
                                     {
                                         "key": "T34",
                                         "name": "T34",
-                                        "visible": false,
                                         "description": "Frostbite with tissue necrosis"
                                     }
                                 ]
@@ -52005,7 +50844,6 @@
                                     {
                                         "key": "T35",
                                         "name": "T35",
-                                        "visible": false,
                                         "description": "Frostbite involving multiple body regions and unspecified frostbite"
                                     }
                                 ]
@@ -52068,7 +50906,6 @@
                                     {
                                         "key": "T36",
                                         "name": "T36",
-                                        "visible": false,
                                         "description": "Poisoning by systemic antibiotics"
                                     }
                                 ]
@@ -52121,7 +50958,6 @@
                                     {
                                         "key": "T37",
                                         "name": "T37",
-                                        "visible": false,
                                         "description": "Poisoning by other systemic anti-infectives and antiparasitics"
                                     }
                                 ]
@@ -52184,7 +51020,6 @@
                                     {
                                         "key": "T38",
                                         "name": "T38",
-                                        "visible": false,
                                         "description": "Poisoning by hormones and their synthetic substitutes and antagonists, not elsewhere classified"
                                     }
                                 ]
@@ -52232,7 +51067,6 @@
                                     {
                                         "key": "T39",
                                         "name": "T39",
-                                        "visible": false,
                                         "description": "Poisoning by nonopioid analgesics, antipyretics and antirheumatics"
                                     }
                                 ]
@@ -52295,7 +51129,6 @@
                                     {
                                         "key": "T40",
                                         "name": "T40",
-                                        "visible": false,
                                         "description": "Poisoning by narcotics and psychodysleptics [hallucinogens]"
                                     }
                                 ]
@@ -52338,7 +51171,6 @@
                                     {
                                         "key": "T41",
                                         "name": "T41",
-                                        "visible": false,
                                         "description": "Poisoning by anaesthetics and therapeutic gases"
                                     }
                                 ]
@@ -52396,7 +51228,6 @@
                                     {
                                         "key": "T42",
                                         "name": "T42",
-                                        "visible": false,
                                         "description": "Poisoning by antiepileptic, sedative-hypnotic and antiparkinsonism drugs"
                                     }
                                 ]
@@ -52454,7 +51285,6 @@
                                     {
                                         "key": "T43",
                                         "name": "T43",
-                                        "visible": false,
                                         "description": "Poisoning by psychotropic drugs, not elsewhere classified"
                                     }
                                 ]
@@ -52517,7 +51347,6 @@
                                     {
                                         "key": "T44",
                                         "name": "T44",
-                                        "visible": false,
                                         "description": "Poisoning by drugs primarily affecting the autonomic nervous system"
                                     }
                                 ]
@@ -52580,7 +51409,6 @@
                                     {
                                         "key": "T45",
                                         "name": "T45",
-                                        "visible": false,
                                         "description": "Poisoning by primarily systemic and haematological agents, not elsewhere classified"
                                     }
                                 ]
@@ -52643,7 +51471,6 @@
                                     {
                                         "key": "T46",
                                         "name": "T46",
-                                        "visible": false,
                                         "description": "Poisoning by agents primarily affecting the cardiovascular system"
                                     }
                                 ]
@@ -52706,7 +51533,6 @@
                                     {
                                         "key": "T47",
                                         "name": "T47",
-                                        "visible": false,
                                         "description": "Poisoning by agents primarily affecting the gastrointestinal system"
                                     }
                                 ]
@@ -52759,7 +51585,6 @@
                                     {
                                         "key": "T48",
                                         "name": "T48",
-                                        "visible": false,
                                         "description": "Poisoning by agents primarily acting on smooth and skeletal muscles and the respiratory system"
                                     }
                                 ]
@@ -52822,7 +51647,6 @@
                                     {
                                         "key": "T49",
                                         "name": "T49",
-                                        "visible": false,
                                         "description": "Poisoning by topical agents primarily affecting skin and mucous membrane and by ophthalmological, otorhinolaryngological and dental drugs"
                                     }
                                 ]
@@ -52885,7 +51709,6 @@
                                     {
                                         "key": "T50",
                                         "name": "T50",
-                                        "visible": false,
                                         "description": "Poisoning by diuretics and other and unspecified drugs, medicaments and biological substances"
                                     }
                                 ]
@@ -52928,7 +51751,6 @@
                                     {
                                         "key": "T51",
                                         "name": "T51",
-                                        "visible": false,
                                         "description": "Toxic effect of alcohol"
                                     }
                                 ]
@@ -52976,7 +51798,6 @@
                                     {
                                         "key": "T52",
                                         "name": "T52",
-                                        "visible": false,
                                         "description": "Toxic effect of organic solvents"
                                     }
                                 ]
@@ -53034,7 +51855,6 @@
                                     {
                                         "key": "T53",
                                         "name": "T53",
-                                        "visible": false,
                                         "description": "Toxic effect of halogen derivatives of aliphatic and aromatic hydrocarbons"
                                     }
                                 ]
@@ -53072,7 +51892,6 @@
                                     {
                                         "key": "T54",
                                         "name": "T54",
-                                        "visible": false,
                                         "description": "Toxic effect of corrosive substances"
                                     }
                                 ]
@@ -53140,7 +51959,6 @@
                                     {
                                         "key": "T56",
                                         "name": "T56",
-                                        "visible": false,
                                         "description": "Toxic effect of metals"
                                     }
                                 ]
@@ -53183,7 +52001,6 @@
                                     {
                                         "key": "T57",
                                         "name": "T57",
-                                        "visible": false,
                                         "description": "Toxic effect of other inorganic substances"
                                     }
                                 ]
@@ -53251,7 +52068,6 @@
                                     {
                                         "key": "T59",
                                         "name": "T59",
-                                        "visible": false,
                                         "description": "Toxic effect of other gases, fumes and vapours"
                                     }
                                 ]
@@ -53299,7 +52115,6 @@
                                     {
                                         "key": "T60",
                                         "name": "T60",
-                                        "visible": false,
                                         "description": "Toxic effect of pesticides"
                                     }
                                 ]
@@ -53337,7 +52152,6 @@
                                     {
                                         "key": "T61",
                                         "name": "T61",
-                                        "visible": false,
                                         "description": "Toxic effect of noxious substances eaten as seafood"
                                     }
                                 ]
@@ -53375,7 +52189,6 @@
                                     {
                                         "key": "T62",
                                         "name": "T62",
-                                        "visible": false,
                                         "description": "Toxic effect of other noxious substances eaten as food"
                                     }
                                 ]
@@ -53433,7 +52246,6 @@
                                     {
                                         "key": "T63",
                                         "name": "T63",
-                                        "visible": false,
                                         "description": "Toxic effect of contact with venomous animals"
                                     }
                                 ]
@@ -53496,7 +52308,6 @@
                                     {
                                         "key": "T65",
                                         "name": "T65",
-                                        "visible": false,
                                         "description": "Toxic effect of other and unspecified substances"
                                     }
                                 ]
@@ -53564,7 +52375,6 @@
                                     {
                                         "key": "T67",
                                         "name": "T67",
-                                        "visible": false,
                                         "description": "Effects of heat and light"
                                     }
                                 ]
@@ -53602,7 +52412,6 @@
                                     {
                                         "key": "T69",
                                         "name": "T69",
-                                        "visible": false,
                                         "description": "Other effects of reduced temperature"
                                     }
                                 ]
@@ -53650,7 +52459,6 @@
                                     {
                                         "key": "T70",
                                         "name": "T70",
-                                        "visible": false,
                                         "description": "Effects of air pressure and water pressure"
                                     }
                                 ]
@@ -53698,7 +52506,6 @@
                                     {
                                         "key": "T73",
                                         "name": "T73",
-                                        "visible": false,
                                         "description": "Effects of other deprivation"
                                     }
                                 ]
@@ -53741,7 +52548,6 @@
                                     {
                                         "key": "T74",
                                         "name": "T74",
-                                        "visible": false,
                                         "description": "Maltreatment syndromes"
                                     }
                                 ]
@@ -53784,7 +52590,6 @@
                                     {
                                         "key": "T75",
                                         "name": "T75",
-                                        "visible": false,
                                         "description": "Effects of other external causes"
                                     }
                                 ]
@@ -53837,7 +52642,6 @@
                                     {
                                         "key": "T78",
                                         "name": "T78",
-                                        "visible": false,
                                         "description": "Adverse effects, not elsewhere classified"
                                     }
                                 ]
@@ -53900,7 +52704,6 @@
                                     {
                                         "key": "T79",
                                         "name": "T79",
-                                        "visible": false,
                                         "description": "Certain early complications of trauma, not elsewhere classified"
                                     }
                                 ]
@@ -53958,7 +52761,6 @@
                                     {
                                         "key": "T80",
                                         "name": "T80",
-                                        "visible": false,
                                         "description": "Complications following infusion, transfusion and therapeutic injection"
                                     }
                                 ]
@@ -54021,7 +52823,6 @@
                                     {
                                         "key": "T81",
                                         "name": "T81",
-                                        "visible": false,
                                         "description": "Complications of procedures, not elsewhere classified"
                                     }
                                 ]
@@ -54084,7 +52885,6 @@
                                     {
                                         "key": "T82",
                                         "name": "T82",
-                                        "visible": false,
                                         "description": "Complications of cardiac and vascular prosthetic devices, implants and grafts"
                                     }
                                 ]
@@ -54142,7 +52942,6 @@
                                     {
                                         "key": "T83",
                                         "name": "T83",
-                                        "visible": false,
                                         "description": "Complications of genitourinary prosthetic devices, implants and grafts"
                                     }
                                 ]
@@ -54205,7 +53004,6 @@
                                     {
                                         "key": "T84",
                                         "name": "T84",
-                                        "visible": false,
                                         "description": "Complications of internal orthopaedic prosthetic devices, implants and grafts"
                                     }
                                 ]
@@ -54268,7 +53066,6 @@
                                     {
                                         "key": "T85",
                                         "name": "T85",
-                                        "visible": false,
                                         "description": "Complications of other internal prosthetic devices, implants and grafts"
                                     }
                                 ]
@@ -54316,7 +53113,6 @@
                                     {
                                         "key": "T86",
                                         "name": "T86",
-                                        "visible": false,
                                         "description": "Failure and rejection of transplanted organs and tissues"
                                     }
                                 ]
@@ -54364,7 +53160,6 @@
                                     {
                                         "key": "T87",
                                         "name": "T87",
-                                        "visible": false,
                                         "description": "Complications peculiar to reattachment and amputation"
                                     }
                                 ]
@@ -54427,7 +53222,6 @@
                                     {
                                         "key": "T88",
                                         "name": "T88",
-                                        "visible": false,
                                         "description": "Other complications of surgical and medical care, not elsewhere classified"
                                     }
                                 ]
@@ -54480,7 +53274,6 @@
                                     {
                                         "key": "T90",
                                         "name": "T90",
-                                        "visible": false,
                                         "description": "Sequelae of injuries of head"
                                     }
                                 ]
@@ -54533,7 +53326,6 @@
                                     {
                                         "key": "T91",
                                         "name": "T91",
-                                        "visible": false,
                                         "description": "Sequelae of injuries of neck and trunk"
                                     }
                                 ]
@@ -54591,7 +53383,6 @@
                                     {
                                         "key": "T92",
                                         "name": "T92",
-                                        "visible": false,
                                         "description": "Sequelae of injuries of upper limb"
                                     }
                                 ]
@@ -54649,7 +53440,6 @@
                                     {
                                         "key": "T93",
                                         "name": "T93",
-                                        "visible": false,
                                         "description": "Sequelae of injuries of lower limb"
                                     }
                                 ]
@@ -54672,7 +53462,6 @@
                                     {
                                         "key": "T94",
                                         "name": "T94",
-                                        "visible": false,
                                         "description": "Sequelae of injuries involving multiple and unspecified body regions"
                                     }
                                 ]
@@ -54720,7 +53509,6 @@
                                     {
                                         "key": "T95",
                                         "name": "T95",
-                                        "visible": false,
                                         "description": "Sequelae of burns, corrosions and frostbite"
                                     }
                                 ]
@@ -54763,7 +53551,6 @@
                                     {
                                         "key": "T98",
                                         "name": "T98",
-                                        "visible": false,
                                         "description": "Sequelae of other and unspecified effects of external causes"
                                     }
                                 ]
@@ -54788,7 +53575,6 @@
                                     {
                                         "key": "U04",
                                         "name": "U04",
-                                        "visible": false,
                                         "description": "Severe acute respiratory syndrome [SARS]"
                                     }
                                 ]
@@ -54821,7 +53607,6 @@
                                     {
                                         "key": "U07",
                                         "name": "U07",
-                                        "visible": false,
                                         "description": "Emergency use of U07"
                                     }
                                 ]
@@ -54839,7 +53624,6 @@
                                     {
                                         "key": "U08",
                                         "name": "U08",
-                                        "visible": false,
                                         "description": "Emergency use of U08"
                                     }
                                 ]
@@ -54923,7 +53707,6 @@
                                     {
                                         "key": "Z00",
                                         "name": "Z00",
-                                        "visible": false,
                                         "description": "General examination and investigation of persons without complaint and reported diagnosis"
                                     }
                                 ]
@@ -54986,7 +53769,6 @@
                                     {
                                         "key": "Z01",
                                         "name": "Z01",
-                                        "visible": false,
                                         "description": "Other special examinations and investigations of persons without complaint or reported diagnosis"
                                     }
                                 ]
@@ -55049,7 +53831,6 @@
                                     {
                                         "key": "Z03",
                                         "name": "Z03",
-                                        "visible": false,
                                         "description": "Medical observation and evaluation for suspected diseases and conditions, ruled out"
                                     }
                                 ]
@@ -55092,7 +53873,6 @@
                                     {
                                         "key": "Z04",
                                         "name": "Z04",
-                                        "visible": false,
                                         "description": "Examination and observation for other reasons"
                                     }
                                 ]
@@ -55135,7 +53915,6 @@
                                     {
                                         "key": "Z08",
                                         "name": "Z08",
-                                        "visible": false,
                                         "description": "Follow-up examination after treatment for malignant neoplasms"
                                     }
                                 ]
@@ -55188,7 +53967,6 @@
                                     {
                                         "key": "Z09",
                                         "name": "Z09",
-                                        "visible": false,
                                         "description": "Follow-up examination after treatment for conditions other than malignant neoplasms"
                                     }
                                 ]
@@ -55256,7 +54034,6 @@
                                     {
                                         "key": "Z12",
                                         "name": "Z12",
-                                        "visible": false,
                                         "description": "Special screening examination for neoplasms"
                                     }
                                 ]
@@ -55314,7 +54091,6 @@
                                     {
                                         "key": "Z13",
                                         "name": "Z13",
-                                        "visible": false,
                                         "description": "Special screening examination for other diseases and disorders"
                                     }
                                 ]
@@ -55377,7 +54153,6 @@
                                     {
                                         "key": "Z20",
                                         "name": "Z20",
-                                        "visible": false,
                                         "description": "Contact with and exposure to communicable diseases"
                                     }
                                 ]
@@ -55440,7 +54215,6 @@
                                     {
                                         "key": "Z22",
                                         "name": "Z22",
-                                        "visible": false,
                                         "description": "Carrier of infectious disease"
                                     }
                                 ]
@@ -55498,7 +54272,6 @@
                                     {
                                         "key": "Z23",
                                         "name": "Z23",
-                                        "visible": false,
                                         "description": "Need for immunization against single bacterial diseases"
                                     }
                                 ]
@@ -55546,7 +54319,6 @@
                                     {
                                         "key": "Z24",
                                         "name": "Z24",
-                                        "visible": false,
                                         "description": "Need for immunization against certain single viral diseases"
                                     }
                                 ]
@@ -55574,7 +54346,6 @@
                                     {
                                         "key": "Z25",
                                         "name": "Z25",
-                                        "visible": false,
                                         "description": "Need for immunization against other single viral diseases"
                                     }
                                 ]
@@ -55602,7 +54373,6 @@
                                     {
                                         "key": "Z26",
                                         "name": "Z26",
-                                        "visible": false,
                                         "description": "Need for immunization against other single infectious diseases"
                                     }
                                 ]
@@ -55650,7 +54420,6 @@
                                     {
                                         "key": "Z27",
                                         "name": "Z27",
-                                        "visible": false,
                                         "description": "Need for immunization against combinations of infectious diseases"
                                     }
                                 ]
@@ -55693,7 +54462,6 @@
                                     {
                                         "key": "Z29",
                                         "name": "Z29",
-                                        "visible": false,
                                         "description": "Need for other prophylactic measures"
                                     }
                                 ]
@@ -55746,7 +54514,6 @@
                                     {
                                         "key": "Z30",
                                         "name": "Z30",
-                                        "visible": false,
                                         "description": "Contraceptive management"
                                     }
                                 ]
@@ -55804,7 +54571,6 @@
                                     {
                                         "key": "Z31",
                                         "name": "Z31",
-                                        "visible": false,
                                         "description": "Procreative management"
                                     }
                                 ]
@@ -55872,7 +54638,6 @@
                                     {
                                         "key": "Z35",
                                         "name": "Z35",
-                                        "visible": false,
                                         "description": "Supervision of high-risk pregnancy"
                                     }
                                 ]
@@ -55925,7 +54690,6 @@
                                     {
                                         "key": "Z36",
                                         "name": "Z36",
-                                        "visible": false,
                                         "description": "Antenatal screening"
                                     }
                                 ]
@@ -55983,7 +54747,6 @@
                                     {
                                         "key": "Z38",
                                         "name": "Z38",
-                                        "visible": false,
                                         "description": "Liveborn infants according to place of birth"
                                     }
                                 ]
@@ -56011,7 +54774,6 @@
                                     {
                                         "key": "Z39",
                                         "name": "Z39",
-                                        "visible": false,
                                         "description": "Postpartum care and examination"
                                     }
                                 ]
@@ -56039,7 +54801,6 @@
                                     {
                                         "key": "Z40",
                                         "name": "Z40",
-                                        "visible": false,
                                         "description": "Prophylactic surgery"
                                     }
                                 ]
@@ -56072,7 +54833,6 @@
                                     {
                                         "key": "Z41",
                                         "name": "Z41",
-                                        "visible": false,
                                         "description": "Procedures for purposes other than remedying health state"
                                     }
                                 ]
@@ -56120,7 +54880,6 @@
                                     {
                                         "key": "Z42",
                                         "name": "Z42",
-                                        "visible": false,
                                         "description": "Follow-up care involving plastic surgery"
                                     }
                                 ]
@@ -56183,7 +54942,6 @@
                                     {
                                         "key": "Z43",
                                         "name": "Z43",
-                                        "visible": false,
                                         "description": "Attention to artificial openings"
                                     }
                                 ]
@@ -56226,7 +54984,6 @@
                                     {
                                         "key": "Z44",
                                         "name": "Z44",
-                                        "visible": false,
                                         "description": "Fitting and adjustment of external prosthetic device"
                                     }
                                 ]
@@ -56269,7 +55026,6 @@
                                     {
                                         "key": "Z45",
                                         "name": "Z45",
-                                        "visible": false,
                                         "description": "Adjustment and management of implanted device"
                                     }
                                 ]
@@ -56332,7 +55088,6 @@
                                     {
                                         "key": "Z46",
                                         "name": "Z46",
-                                        "visible": false,
                                         "description": "Fitting and adjustment of other devices"
                                     }
                                 ]
@@ -56360,7 +55115,6 @@
                                     {
                                         "key": "Z47",
                                         "name": "Z47",
-                                        "visible": false,
                                         "description": "Other orthopaedic follow-up care"
                                     }
                                 ]
@@ -56388,7 +55142,6 @@
                                     {
                                         "key": "Z48",
                                         "name": "Z48",
-                                        "visible": false,
                                         "description": "Other surgical follow-up care"
                                     }
                                 ]
@@ -56416,7 +55169,6 @@
                                     {
                                         "key": "Z49",
                                         "name": "Z49",
-                                        "visible": false,
                                         "description": "Care involving dialysis"
                                     }
                                 ]
@@ -56474,7 +55226,6 @@
                                     {
                                         "key": "Z51",
                                         "name": "Z51",
-                                        "visible": false,
                                         "description": "Other medical care"
                                     }
                                 ]
@@ -56537,7 +55288,6 @@
                                     {
                                         "key": "Z52",
                                         "name": "Z52",
-                                        "visible": false,
                                         "description": "Donors of organs and tissues"
                                     }
                                 ]
@@ -56610,7 +55360,6 @@
                                     {
                                         "key": "Z64",
                                         "name": "Z64",
-                                        "visible": false,
                                         "description": "Problems related to certain psychosocial circumstances"
                                     }
                                 ]
@@ -56653,7 +55402,6 @@
                                     {
                                         "key": "Z72",
                                         "name": "Z72",
-                                        "visible": false,
                                         "description": "Problems related to lifestyle"
                                     }
                                 ]
@@ -56701,7 +55449,6 @@
                                     {
                                         "key": "Z74",
                                         "name": "Z74",
-                                        "visible": false,
                                         "description": "Problems related to care-provider dependency"
                                     }
                                 ]
@@ -56729,7 +55476,6 @@
                                     {
                                         "key": "Z75",
                                         "name": "Z75",
-                                        "visible": false,
                                         "description": "Problems related to medical facilities and other health care"
                                     }
                                 ]
@@ -56777,7 +55523,6 @@
                                     {
                                         "key": "Z76",
                                         "name": "Z76",
-                                        "visible": false,
                                         "description": "Persons encountering health services in other circumstances"
                                     }
                                 ]
@@ -56840,7 +55585,6 @@
                                     {
                                         "key": "Z80",
                                         "name": "Z80",
-                                        "visible": false,
                                         "description": "Family history of malignant neoplasm"
                                     }
                                 ]
@@ -56898,7 +55642,6 @@
                                     {
                                         "key": "Z83",
                                         "name": "Z83",
-                                        "visible": false,
                                         "description": "Family history of other specific disorders"
                                     }
                                 ]
@@ -56936,7 +55679,6 @@
                                     {
                                         "key": "Z84",
                                         "name": "Z84",
-                                        "visible": false,
                                         "description": "Family history of other conditions"
                                     }
                                 ]
@@ -56999,7 +55741,6 @@
                                     {
                                         "key": "Z85",
                                         "name": "Z85",
-                                        "visible": false,
                                         "description": "Personal history of malignant neoplasm"
                                     }
                                 ]
@@ -57052,7 +55793,6 @@
                                     {
                                         "key": "Z86",
                                         "name": "Z86",
-                                        "visible": false,
                                         "description": "Personal history of certain other diseases"
                                     }
                                 ]
@@ -57110,7 +55850,6 @@
                                     {
                                         "key": "Z87",
                                         "name": "Z87",
-                                        "visible": false,
                                         "description": "Personal history of other diseases and conditions"
                                     }
                                 ]
@@ -57173,7 +55912,6 @@
                                     {
                                         "key": "Z88",
                                         "name": "Z88",
-                                        "visible": false,
                                         "description": "Personal history of allergy to drugs, medicaments and biological substances"
                                     }
                                 ]
@@ -57236,7 +55974,6 @@
                                     {
                                         "key": "Z89",
                                         "name": "Z89",
-                                        "visible": false,
                                         "description": "Acquired absence of limb"
                                     }
                                 ]
@@ -57294,7 +56031,6 @@
                                     {
                                         "key": "Z90",
                                         "name": "Z90",
-                                        "visible": false,
                                         "description": "Acquired absence of organs, not elsewhere classified"
                                     }
                                 ]
@@ -57327,7 +56063,6 @@
                                     {
                                         "key": "Z91",
                                         "name": "Z91",
-                                        "visible": false,
                                         "description": "Personal history of risk-factors, not elsewhere classified"
                                     }
                                 ]
@@ -57375,7 +56110,6 @@
                                     {
                                         "key": "Z92",
                                         "name": "Z92",
-                                        "visible": false,
                                         "description": "Personal history of medical treatment"
                                     }
                                 ]
@@ -57433,7 +56167,6 @@
                                     {
                                         "key": "Z93",
                                         "name": "Z93",
-                                        "visible": false,
                                         "description": "Artificial opening status"
                                     }
                                 ]
@@ -57496,7 +56229,6 @@
                                     {
                                         "key": "Z94",
                                         "name": "Z94",
-                                        "visible": false,
                                         "description": "Transplanted organ and tissue status"
                                     }
                                 ]
@@ -57549,7 +56281,6 @@
                                     {
                                         "key": "Z95",
                                         "name": "Z95",
-                                        "visible": false,
                                         "description": "Presence of cardiac and vascular implants and grafts"
                                     }
                                 ]
@@ -57612,7 +56343,6 @@
                                     {
                                         "key": "Z96",
                                         "name": "Z96",
-                                        "visible": false,
                                         "description": "Presence of other functional implants"
                                     }
                                 ]
@@ -57635,7 +56365,6 @@
                                     {
                                         "key": "Z97",
                                         "name": "Z97",
-                                        "visible": false,
                                         "description": "Presence of other devices"
                                     }
                                 ]
@@ -57668,7 +56397,6 @@
                                     {
                                         "key": "Z98",
                                         "name": "Z98",
-                                        "visible": false,
                                         "description": "Other postsurgical states"
                                     }
                                 ]
@@ -57716,7 +56444,6 @@
                                     {
                                         "key": "Z99",
                                         "name": "Z99",
-                                        "visible": false,
                                         "description": "Dependence on enabling machines and devices, not elsewhere classified"
                                     }
                                 ]


### PR DESCRIPTION
Zdenka wanted that it also allows you to search for e.g. plain "A00", so I removed the `"visible": false` everywhere.