### PR TITLE
chore: prevent caching of catalogue and options json files

### DIFF
--- a/src/services/catalogue.service.ts
+++ b/src/services/catalogue.service.ts
@@ -8,11 +8,15 @@ export const fetchData = async (
 	catalogueUrl: string,
 	optionsUrl: string
 ): Promise<{ catalogueJSON: string; optionsJSON: string }> => {
-	const cataloguePromise: string = await fetch(catalogueUrl).then((response) =>
+	const cacheBuster = `?cb=${Date.now()}`;
+	const catUrl = catalogueUrl + cacheBuster;
+	const optUrl = optionsUrl + cacheBuster;
+
+	const cataloguePromise: string = await fetch(catUrl, { cache: 'reload' }).then((response) =>
 		response.text()
 	);
 
-	const optionsPromise: string = await fetch(optionsUrl).then((response) =>
+	const optionsPromise: string = await fetch(optUrl, { cache: 'reload' }).then((response) =>
 		response.text()
 	);
 

--- a/src/services/catalogue.service.ts
+++ b/src/services/catalogue.service.ts
@@ -9,14 +9,12 @@ export const fetchData = async (
 	optionsUrl: string
 ): Promise<{ catalogueJSON: string; optionsJSON: string }> => {
 	const cacheBuster = `?cb=${Date.now()}`;
-	const catUrl = catalogueUrl + cacheBuster;
-	const optUrl = optionsUrl + cacheBuster;
 
-	const cataloguePromise: string = await fetch(catUrl, { cache: 'reload' }).then((response) =>
+	const cataloguePromise: string = await fetch(catalogueUrl + cacheBuster, { cache: 'reload' }).then((response) =>
 		response.text()
 	);
 
-	const optionsPromise: string = await fetch(optUrl, { cache: 'reload' }).then((response) =>
+	const optionsPromise: string = await fetch(optionsUrl + cacheBuster, { cache: 'reload' }).then((response) =>
 		response.text()
 	);
 


### PR DESCRIPTION
The reason that we always have to delete cache for the new version to work might be that the options and catalogue json files are cached. If so, this PR should fix it.