### PR TITLE
Fix rounding "tooltips"

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -170,7 +170,7 @@
           ? (value: number) =>
               value == 0
                 ? "Exact value"
-                : `Rounded to the nearest multiple of ${Math.pow(10, Math.ceil(Math.log(value) / Math.log(10) / 2))}`
+                : `Rounded to the nearest multiple of ${Math.pow(10, Math.ceil(Math.log10(value) / 2))}`
           : undefined}
       ></lens-result-table>
       <lens-search-modified-display></lens-search-modified-display>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -170,7 +170,7 @@
           ? (value: number) =>
               value == 0
                 ? "Exact value"
-                : `Rounded to the nearest multiple of ${Math.pow(10, Math.ceil(Math.log(value)/Math.log(10)/2))}`
+                : `Rounded to the nearest multiple of ${Math.pow(10, Math.ceil(Math.log(value) / Math.log(10) / 2))}`
           : undefined}
       ></lens-result-table>
       <lens-search-modified-display></lens-search-modified-display>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -170,7 +170,7 @@
           ? (value: number) =>
               value == 0
                 ? "Exact value"
-                : `Rounded to the nearest multiple of ${Math.pow(10, Math.floor(String(value).length / 2))}`
+                : `Rounded to the nearest multiple of ${Math.pow(10, Math.ceil(Math.log(value)/Math.log(10)/2))}`
           : undefined}
       ></lens-result-table>
       <lens-search-modified-display></lens-search-modified-display>


### PR DESCRIPTION
### General Summary

Fix rounding "tooltips"

### Description

Switched to logarithms instead of converting to string and getting the length
Ceil instead of floor

### Related Issue


---

### Motivation and Context

The numbers of significant and insignificant digits were mixed up. Additionally, logarithms are faster than converting to strings!

### How Has This Been Tested?
We'll test in Test

### Screenshots (if appropriate):

---

<!--- Please check if the PR fulfills these requirements -->

- [ ] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
