### PR TITLE
fix: use latest Aviano-CRO collection

### DIFF
--- a/src/config/options.json
+++ b/src/config/options.json
@@ -12,7 +12,7 @@
     },
     "aviano-cro": {
       "displayName": "Aviano-CRO",
-      "collectionId": "bbmri-eric:ID:IT_138555353610847:collection:Principia"
+      "collectionId": "bbmri-eric:ID:IT_138555353610847:collection:ae678e27f44c402191cd62a3d9472332"
     },
     "berlin": {
       "displayName": "Berlin",


### PR DESCRIPTION
### General Summary

### Description

Use the most recent default collection ID for Aviano-CRO

### Related Issue

<!--- Please link to the issue here: -->

---

### Motivation and Context

### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

### Screenshots (if appropriate):

---

<!--- Please check if the PR fulfills these requirements -->

- [ ] The commit message follows guidelines
- [ ] Tests for the changes have been added
- [ ] Documentation has been added/ updated
