### PR TITLE
feat: scroll to results on search

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -74,6 +74,7 @@
 
   window.addEventListener("lens-search-triggered", () => {
     sendQuery();
+    scrollToResults();
   });
 
   onMount(async () => {
@@ -113,6 +114,12 @@
     // Using setTimeout to ensure the custom element's onMount has completed.
     setTimeout(() => sendQuery(), 0);
   });
+
+  let results: HTMLElement;
+
+  function scrollToResults() {
+    results.scrollIntoView({ behavior: "smooth" });
+  }
 </script>
 
 <div class="banner">
@@ -159,7 +166,7 @@
     ></lens-catalogue>
   </div>
 
-  <div class="charts">
+  <div class="charts" bind:this={results}>
     <div class="chart-wrapper result-summary">
       <lens-result-summary></lens-result-summary>
     </div>


### PR DESCRIPTION
### General Summary
Radovan requestet the following in the Lens repository:

If I have the search parameters dropdown toggled and after adding some parameters, I click "Search", nothing happens. I have to scroll down to the results to see if something is happening. Please implement a change of focus to the results after clicking search, with a gentle animation

This isn't a library issue because layouts can vary, so i implemented it in the locator itself.

### Description

When the search button is clicked, the window scrolls smoothly to the results section.

### Related Issue

https://github.com/samply/lens/issues/759


### How Has This Been Tested?

UI test